### PR TITLE
"Now Playing" improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Changed
 - Use PHP attributes instead of annotations to get rid of deprecation warnings in the debug log on NC 31+
+- Subsonic API:
+  * Set the "now playing" data locally and in the connected Last.fm account when the client calls `scrobble` with `submission=false`
+    [#112](https://github.com/nc-music/music/pull/112) @mattwellss
 
 ### Fixed
 - When no local album art available, the art from Last.fm was accidentally applied also to the artist list of the album details pane

--- a/lib/BusinessLayer/TrackBusinessLayer.php
+++ b/lib/BusinessLayer/TrackBusinessLayer.php
@@ -241,10 +241,15 @@ class TrackBusinessLayer extends BusinessLayer implements Scrobbler {
 
 	/**
 	 * Return the "now playing" track along with its time of play
-	 * @return array{track: Track, timeOfPlay: \DateTimeInterface}
+	 * @return array{trackId: int, timeOfPlay: int}
 	 */
 	public function getNowPlaying(string $userId) : array {
-		return $this->mapper->getNowPlaying($userId);
+		$nowPlaying = $this->mapper->getNowPlaying($userId);
+		if (!$nowPlaying) {
+			throw new BusinessLayerException('Malformed now playing data');
+		}
+
+		return $nowPlaying;
 	}
 
 	/**

--- a/lib/BusinessLayer/TrackBusinessLayer.php
+++ b/lib/BusinessLayer/TrackBusinessLayer.php
@@ -266,7 +266,7 @@ class TrackBusinessLayer extends BusinessLayer implements Scrobbler {
 
 	/**
 	 * Return the "now playing" track along with its time of play
-	 * @return ?array{track: Track, timeOfPlay: int}, null if no data available
+	 * @return ?array{track: Track, timeOfPlay: int} - null if no data available
 	 * @throws BusinessLayerException if data available but somehow incorrect
 	 */
 	public function getNowPlaying(string $userId) : ?array {

--- a/lib/BusinessLayer/TrackBusinessLayer.php
+++ b/lib/BusinessLayer/TrackBusinessLayer.php
@@ -226,6 +226,7 @@ class TrackBusinessLayer extends BusinessLayer implements Scrobbler {
 		if (!$this->mapper->recordTrackPlayed($trackId, $userId, $timeOfPlay)) {
 			throw new BusinessLayerException("Track with ID $trackId was not found");
 		}
+		$this->setNowPlaying($trackId, $userId, $timeOfPlay);
 	}
 
 	/**

--- a/lib/BusinessLayer/TrackBusinessLayer.php
+++ b/lib/BusinessLayer/TrackBusinessLayer.php
@@ -233,6 +233,21 @@ class TrackBusinessLayer extends BusinessLayer implements Scrobbler {
 	}
 
 	/**
+	 * Save the track to config as the "now playing" track with the provided timestamp
+	 */
+	public function setNowPlaying(int $trackId, string $userId, ?\DateTime $timeOfPlay = null) : void {
+		$this->mapper->setNowPlaying($trackId, $userId, $timeOfPlay ?? new \DateTime());
+	}
+
+	/**
+	 * Return the "now playing" track along with its time of play
+	 * @return array{track: Track, timeOfPlay: \DateTimeInterface}
+	 */
+	public function getNowPlaying(string $userId) : array {
+		return $this->mapper->getNowPlaying($userId);
+	}
+
+	/**
 	 * Adds a track if it does not exist already or updates an existing track
 	 * @param string $title the title of the track
 	 * @param int|null $number the number of the track

--- a/lib/Controller/SubsonicController.php
+++ b/lib/Controller/SubsonicController.php
@@ -1106,20 +1106,18 @@ class SubsonicController extends ApiController {
 		$apiTrack = [];
 		try {
 			$nowPlaying = $this->trackBusinessLayer->getNowPlaying($this->user());
-			$track = $nowPlaying['track'];
-			if (!empty($track)) {;
+			if ($nowPlaying !== null) {;
 				$now = new \DateTime();
-				$apiTrack = $this->tracksToApi([$track]);
-				$apiTrack[0]['username'] = $this->user();
-				$apiTrack[0]['minutesAgo'] = (int)(($now->getTimestamp() - $nowPlaying['timeOfPlay']) / 60);
-				$apiTrack[0]['playerId'] = 0; // dummy
+				$apiTrack = $this->trackToApi($nowPlaying['track']);
+				$apiTrack['username'] = $this->user();
+				$apiTrack['minutesAgo'] = (int)(($now->getTimestamp() - $nowPlaying['timeOfPlay']) / 60);
+				$apiTrack['playerId'] = 0; // dummy
 			}
 		} catch (BusinessLayerException $e) {
 			$this->logger->warning($e->getMessage());
 		}
 
-
-		return ['nowPlaying' => ['entry' => $apiTrack]];
+		return ['nowPlaying' => ['entry' => [$apiTrack]]];
 	}
 
 	#[SubsonicAPI]

--- a/lib/Controller/SubsonicController.php
+++ b/lib/Controller/SubsonicController.php
@@ -1095,7 +1095,7 @@ class SubsonicController extends ApiController {
 		$apiTrack = [];
 		try {
 			$nowPlaying = $this->trackBusinessLayer->getNowPlaying($this->user());
-			$track = $this->trackBusinessLayer->find($nowPlaying['trackId'], $this->user());
+			$track = $nowPlaying['track'];
 			if (!empty($track)) {;
 				$now = new \DateTime();
 				$apiTrack = $this->tracksToApi([$track]);

--- a/lib/Db/TrackMapper.php
+++ b/lib/Db/TrackMapper.php
@@ -24,7 +24,7 @@ use OCP\IDBConnection;
  */
 class TrackMapper extends BaseMapper {
 
-	public function __construct(IDBConnection $db, private IConfig $config) {
+	public function __construct(IDBConnection $db, IConfig $config) {
 		parent::__construct($db, $config, 'music_tracks', Track::class, 'title', ['file_id', 'user_id'], 'album_id');
 	}
 
@@ -552,34 +552,6 @@ class TrackMapper extends BaseMapper {
 		$result->closeCursor();
 
 		return $updated;
-	}
-
-	public function setNowPlaying(int $trackId, string $userId, \DateTime $timeOfPlay) : void {
-		// validate track exists
-		$this->find($trackId, $userId);
-		$data = [
-			'trackId' => $trackId,
-			'timeOfPlay' => $timeOfPlay->getTimestamp()
-		];
-		$this->config->setUserValue($userId, 'music', 'music.nowPlaying', \json_encode($data));
-	}
-
-	/**
-	 * @return array{trackId: int|null, timeOfPlay: int|null}|null
-	 */
-	public function getNowPlaying(string $userId) : ?array {
-		$nowPlayingData = $this->config->getUserValue($userId, 'music', 'music.nowPlaying');
-		$nowPlaying = \array_filter(
-			\array_merge(['trackId' => null, 'timeOfPlay' => null], \json_decode($nowPlayingData, true)),
-			fn ($val, $key) => \in_array($key, ['trackId', 'timeOfPlay']),
-			\ARRAY_FILTER_USE_BOTH
-		);
-		foreach ($nowPlaying as $value) {
-			if ($value === null) {
-				return null;
-			}
-		}
-		return $nowPlaying;
 	}
 
 	/**

--- a/lib/Service/AggregateScrobbler.php
+++ b/lib/Service/AggregateScrobbler.php
@@ -27,4 +27,10 @@ class AggregateScrobbler implements Scrobbler {
 			$scrobbler->recordTrackPlayed($trackId, $userId, $timeOfPlay);
 		}
 	}
+
+	public function setNowPlaying(int $trackId, string $userId, ?\DateTime $timeOfPlay = null): void {
+		foreach ($this->scrobblers as $scrobbler) {
+			$scrobbler->setNowPlaying($trackId, $userId, $timeOfPlay);
+		}
+	}
 }

--- a/lib/Service/Scrobbler.php
+++ b/lib/Service/Scrobbler.php
@@ -14,4 +14,5 @@ namespace OCA\Music\Service;
 
 interface Scrobbler {
 	public function recordTrackPlayed(int $trackId, string $userId, ?\DateTime $timeOfPlay = null) : void;
+	public function setNowPlaying(int $trackId, string $userId, ?\DateTime $timeOfPlay = null) : void;
 }

--- a/lib/Utility/Concurrency.php
+++ b/lib/Utility/Concurrency.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+/**
+ * ownCloud - Music app
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
+ * @copyright Pauli Järvinen 2026
+ */
+
+namespace OCA\Music\Utility;
+
+use OCA\Music\AppFramework\Core\Logger;
+use OCA\Music\Db\Cache;
+
+class Concurrency {
+	private const SEMAPHORE_KEY_BASE = 0xa5e63947; // arbitrarily selected 32-bit base value
+
+	public function __construct(private Cache $cache, private Logger $logger) {
+	}
+
+	public function mutexReserve(string $userId, string $key) : false|\SysvSemaphore {
+		if (!\extension_loaded('sysvsem')) {
+			$this->logger->warning('PHP extension sysvsem should be installed to guarantee correct behavior');
+			return false;
+		}
+
+		$mutexKey = self::SEMAPHORE_KEY_BASE + $this->cache->forcedGetId($userId, "mutex_key.$key");
+		$mutex = \sem_get($mutexKey);
+
+		if ($mutex !== false) {
+			\sem_acquire($mutex);
+		} else {
+			$this->logger->warning('Failed to acquire the semaphore');
+		}
+
+		return $mutex;
+	}
+
+	public function mutexRelease(false|\SysvSemaphore $mutex) : void {
+		if ($mutex !== false) {
+			\sem_release($mutex);
+		}
+	}
+}

--- a/tests/php/unit/businesslayer/TrackBusinessLayerTest.php
+++ b/tests/php/unit/businesslayer/TrackBusinessLayerTest.php
@@ -9,16 +9,16 @@
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
  * @copyright Morris Jobke 2013, 2014
- * @copyright Pauli Järvinen 2016 - 2025
+ * @copyright Pauli Järvinen 2016 - 2026
  */
 
 namespace OCA\Music\BusinessLayer;
 
 use OCA\Music\AppFramework\Core\Logger;
+use OCA\Music\Db\Cache;
 use OCA\Music\Db\Track;
 use OCA\Music\Db\TrackMapper;
 use OCA\Music\Service\FileSystemService;
-use OCP\IConfig;
 
 class TrackBusinessLayerTest extends \PHPUnit\Framework\TestCase {
 	private $mapper;
@@ -29,7 +29,7 @@ class TrackBusinessLayerTest extends \PHPUnit\Framework\TestCase {
 	private $artistId;
 	private $albumId;
 	private $fileId;
-	private $config;
+	private $cache;
 
 	protected function setUp() : void {
 		$this->mapper = $this->getMockBuilder(TrackMapper::class)
@@ -41,9 +41,10 @@ class TrackBusinessLayerTest extends \PHPUnit\Framework\TestCase {
 		$this->logger = $this->getMockBuilder(Logger::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->config = $this->getMockBuilder(IConfig::class)
+		$this->cache = $this->getMockBuilder(Cache::class)
+			->disableOriginalConstructor()
 			->getMock();
-		$this->trackBusinessLayer = new TrackBusinessLayer($this->mapper, $this->fileSystemService, $this->logger, $this->config);
+		$this->trackBusinessLayer = new TrackBusinessLayer($this->mapper, $this->fileSystemService, $this->logger, $this->cache);
 		$this->userId = 'jack';
 		$this->artistId = 3;
 		$this->albumId = 3;

--- a/tests/php/unit/businesslayer/TrackBusinessLayerTest.php
+++ b/tests/php/unit/businesslayer/TrackBusinessLayerTest.php
@@ -18,6 +18,7 @@ use OCA\Music\AppFramework\Core\Logger;
 use OCA\Music\Db\Track;
 use OCA\Music\Db\TrackMapper;
 use OCA\Music\Service\FileSystemService;
+use OCP\IConfig;
 
 class TrackBusinessLayerTest extends \PHPUnit\Framework\TestCase {
 	private $mapper;
@@ -28,6 +29,7 @@ class TrackBusinessLayerTest extends \PHPUnit\Framework\TestCase {
 	private $artistId;
 	private $albumId;
 	private $fileId;
+	private $config;
 
 	protected function setUp() : void {
 		$this->mapper = $this->getMockBuilder(TrackMapper::class)
@@ -39,7 +41,9 @@ class TrackBusinessLayerTest extends \PHPUnit\Framework\TestCase {
 		$this->logger = $this->getMockBuilder(Logger::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->trackBusinessLayer = new TrackBusinessLayer($this->mapper, $this->fileSystemService, $this->logger);
+		$this->config = $this->getMockBuilder(IConfig::class)
+			->getMock();
+		$this->trackBusinessLayer = new TrackBusinessLayer($this->mapper, $this->fileSystemService, $this->logger, $this->config);
 		$this->userId = 'jack';
 		$this->artistId = 3;
 		$this->albumId = 3;


### PR DESCRIPTION
Provides the currently playing track for Subsonic clients (web api and [ampache](https://github.com/ampache/ampache/issues/3644) do not currently expose a means of setting the now playing track).

For clients that retrieve the nowPlaying track, responds with the one stored in `oc_preferences`.

Sets the "now playing" track in Last.fm.