### PR TITLE
Only scrobble tracks of 30 seconds or longer

### DIFF
--- a/lib/Service/ExternalScrobbler.php
+++ b/lib/Service/ExternalScrobbler.php
@@ -138,6 +138,13 @@ class ExternalScrobbler implements Scrobbler {
 		$tracks = $this->trackBusinessLayer->findById([$trackId], $userId);
 		$this->albumBusinessLayer->injectAlbumsToTracks($tracks, $userId);
 		foreach ($tracks as $i => $track) {
+			// Last.fm's docs say a track must be >30 seconds in order to scrobble
+			// This scrobbler uses the Last.fm Scrobbler 2.0 spec, so we follow that rule
+			// https://www.last.fm/api/scrobbling#when-is-a-scrobble-a-scrobble
+			if ($track->getLength() <= 30) {
+				return;
+			}
+
 			$trackData = $this->generateTrackData($track);
 			if (isset($trackData['albumArtist'])) {
 				$scrobbleData["albumArtist[{$i}]"] = $trackData['albumArtist'];


### PR DESCRIPTION
Resolves an issue with external scrobbling where tracks too short for scrobbling to Last.fm are sent there anyway

re: https://github.com/nc-music/music/pull/112#discussion_r2700154046