### PR TITLE
fix: confirm before removing unavailable files; rescan on same-path pick

### DIFF
--- a/js/app/controllers/maincontroller.js
+++ b/js/app/controllers/maincontroller.js
@@ -309,7 +309,7 @@ function ($rootScope, $scope, $document, $timeout, $window, ArtistFactory,
 		const count = $scope.obsoleteFiles.length;
 		OC.dialogs.confirm(
 			gettextCatalog.getPlural(count,
-				'One previously scanned file is no longer available. Remove it from the collection?',
+				'{{ count }} previously scanned file is no longer available. Remove it from the collection?',
 				'{{ count }} previously scanned files are no longer available. Remove them from the collection?',
 				{ count: count }),
 			gettextCatalog.getString('Remove unavailable files'),

--- a/js/app/controllers/maincontroller.js
+++ b/js/app/controllers/maincontroller.js
@@ -306,11 +306,26 @@ function ($rootScope, $scope, $document, $timeout, $window, ArtistFactory,
 	};
 
 	$scope.removeObsolete = function() {
-		Restangular.all('removescanned').post({files: $scope.obsoleteFiles.join(',')}).then(_result => {
-			$scope.obsoleteFiles = null;
-			$scope.update();
-		});
+		const count = $scope.obsoleteFiles.length;
+		OC.dialogs.confirm(
+			gettextCatalog.getPlural(count,
+				'One previously scanned file is no longer available. Remove it from the collection?',
+				'{{ count }} previously scanned files are no longer available. Remove them from the collection?',
+				{ count: count }),
+			gettextCatalog.getString('Remove unavailable files'),
+			function(confirmed) {
+				if (confirmed) {
+					Restangular.all('removescanned').post({files: $scope.obsoleteFiles.join(',')}).then(_result => {
+						$scope.obsoleteFiles = null;
+						$scope.update();
+					});
+				}
+			},
+			true
+		);
 	};
+
+	$scope.updateFilesToScan = updateFilesToScan; // exposed for child controllers
 
 	$scope.resetScanned = function() {
 		$scope.unscannedFiles = null;

--- a/js/app/controllers/views/settingsviewcontroller.js
+++ b/js/app/controllers/views/settingsviewcontroller.js
@@ -65,6 +65,10 @@ angular.module('Music').controller('SettingsViewController', [
 								$scope.errorPath = true;
 							}
 						);
+					} else {
+						// Same path re-selected: check for unscanned/obsolete files without
+						// reloading the full collection.
+						$scope.$parent.updateFilesToScan();
 					}
 				}
 			);


### PR DESCRIPTION
## Summary

- **Fix 1 (closes #138):** `removeObsolete()` now shows a `OC.dialogs.confirm()` dialog before calling `POST /api/removescanned`. Without this, a single click on the "N files not available" banner permanently deleted the entire collection with no warning. The dialog is plural-aware (uses `gettextCatalog.getPlural`) and defaults to "No" (the `true` parameter makes it a "critical" dialog).

- **Fix 2 (closes #139):** `SettingsViewController.selectPath()` now has an `else` branch for when the user picks the same path that is already configured. Instead of doing nothing, it calls `$scope.$parent.updateFilesToScan()` — the same check that runs on startup — so newly-available or unscanned files are detected without a full collection reload.

## Background

Both issues were discovered in a production environment. A transient Nextcloud group-folder mount failure made ~69,000 tracks appear as "not available". One click on the banner wiped the entire collection and all playlists. The files were intact but there was no obvious way to re-trigger scanning — re-selecting the same music path in Settings appeared to be the natural solution, but it was a no-op.

## Files changed

- `js/app/controllers/maincontroller.js` — confirmation dialog in `removeObsolete()`, expose `updateFilesToScan` on `$scope`
- `js/app/controllers/views/settingsviewcontroller.js` — `else` branch in `selectPath()` calling `$scope.$parent.updateFilesToScan()`

## Testing

Tested against a local Nextcloud 33 instance with the Music app mounted as a custom app:

**Fix 1:** Renamed the music folder to make files appear unavailable, reloaded the app, clicked the banner → confirmation dialog appeared with "No" / "Yes" buttons. Clicking "No" dismissed the dialog without deleting anything.

**Fix 2:** With the music folder restored, opened Settings, opened the folder picker, and re-selected the same `/music/` path → the app immediately issued a `GET /api/scanstate` request (captured via network interception), confirming `updateFilesToScan()` was called.