### PR TITLE
perf: pre-fetch folders in parallel with music collection

### DIFF
--- a/js/app/controllers/maincontroller.js
+++ b/js/app/controllers/maincontroller.js
@@ -123,6 +123,8 @@ function ($rootScope, $scope, $document, $timeout, $window, ArtistFactory,
 		libraryService.setIgnoredArticles(ignoredArticles);
 	});
 
+	let pendingFoldersLoad = null;
+
 	$scope.update = function() {
 		$scope.updateAvailable = false;
 		$rootScope.loadingCollection = true;
@@ -130,6 +132,13 @@ function ($rootScope, $scope, $document, $timeout, $window, ArtistFactory,
 		$scope.artists = null; // the null-value tells the views that data is not yet available
 		libraryService.setFolders(null); // invalidate any out-dated folders
 		$rootScope.$emit('collectionUpdating');
+
+		// Pre-fetch folders in parallel with the main collection so the Folders
+		// view doesn't have to wait for the full 10+ MB collection response.
+		pendingFoldersLoad = Restangular.one('folders').get().then(function(folders) {
+			libraryService.setFolders(folders);
+			pendingFoldersLoad = null;
+		});
 
 		// load the music collection
 		ArtistFactory.getArtists().then(function(artists) {
@@ -327,6 +336,8 @@ function ($rootScope, $scope, $document, $timeout, $window, ArtistFactory,
 	$scope.loadFoldersAndThen = function(callback) {
 		if (libraryService.foldersLoaded()) {
 			$timeout(callback);
+		} else if (pendingFoldersLoad) {
+			pendingFoldersLoad.then(callback);
 		} else {
 			Restangular.one('folders').get().then(function (folders) {
 				libraryService.setFolders(folders);


### PR DESCRIPTION
## Summary

- On large libraries (70 000+ tracks), `/api/collection` returns ~10 MB of JSON that takes the browser 15+ seconds to process through Angular's digest cycle
- `/api/folders` was only requested _after_ `collectionLoaded` fired, serialising a 3–4 s network round-trip behind that 15 s browser gap
- This PR starts the folders fetch immediately when `update()` runs (in parallel with the collection) and stores the promise so `loadFoldersAndThen()` can chain onto it — shaving the full sequential wait off the Folders view load time on large libraries

## How it works

A `pendingFoldersLoad` promise is created at the top of `$scope.update()` alongside `ArtistFactory.getArtists()`. `loadFoldersAndThen()` gains an `else if (pendingFoldersLoad)` branch: if the pre-fetch is still in flight it chains the callback onto it; if it already resolved (the common case, since the 895 KB folders response arrives well before Angular finishes chewing through the collection) `libraryService.foldersLoaded()` is true and the existing fast path fires immediately.

No behaviour change for small libraries where both responses arrive quickly.

## Test plan

- [ ] Open Music app → Folders view with a large library; verify folders appear noticeably sooner than before
- [ ] Open Music app → Folders view with a small library; verify folders still appear correctly
- [ ] Trigger `$scope.update()` manually (e.g. via Settings → rescan); verify folders reload correctly afterwards
- [ ] Verify no duplicate `/api/folders` requests appear in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)