### PR TITLE
Ampache API: Fix the album cover and artist photo handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@
 - Extensive internal refactoring on the web UI
 
 ### Fixed
+- An image file named after an artist no longer doubles as the cover of the album in the same folder, unless the folder has no other image. A rescan is needed for this to take effect on an existing library
+  [#102](https://github.com/nc-music/music/issues/102)
+- Ampache API:
+  * Property `art` is now always a valid URL like on the original Ampache server, and the clients should use the property `has_art` to tell whether it resolves to a real image
+  * Art URL was broken if the API key used on the handshake had been deleted since
+  * Art fetched with the action `get_art` was not cached by the clients, unlike the art fetched from `image.php`
+    [#102](https://github.com/nc-music/music/issues/102)
 - HTTP redirection not working (e.g. on radio streams) when the `Location` header contains a relative URL
 - Deprecation warnings printed on PHP 8.3+ while executing the Music background tasks
 - Web UI trying to load an invalid image URL upon page load

--- a/lib/Controller/AmpacheController.php
+++ b/lib/Controller/AmpacheController.php
@@ -61,6 +61,7 @@ use OCA\Music\Service\PodcastService;
 use OCA\Music\Service\Scrobbling\IScrobbler;
 use OCA\Music\Utility\AppInfo;
 use OCA\Music\Utility\ArrayUtil;
+use OCA\Music\Utility\HttpUtil;
 use OCA\Music\Utility\Random;
 use OCA\Music\Utility\StringUtil;
 use OCA\Music\Utility\Util;
@@ -1575,7 +1576,11 @@ class AmpacheController extends ApiController {
 			$entity = $businessLayer->find($entityId, $userId);
 			$coverData = $this->coverService->getCover($entity, $userId, $userFolder, $size);
 			if ($coverData !== null) {
-				return new FileResponse($coverData);
+				$response = new FileResponse($coverData);
+				// Without this, clients re-fetch the art on every use of the object. The cover of an entity may
+				// change, but the same is true of the images served by `image.php`, which caches for 30 days.
+				HttpUtil::setClientCachingDays($response, 30);
+				return $response;
 			}
 		} catch (BusinessLayerException $e) {
 			return new ErrorResponse(Http::STATUS_NOT_FOUND, 'entity not found');
@@ -1656,14 +1661,17 @@ class AmpacheController extends ApiController {
 			// For internal clients, we don't need to create URLs with permanent but API-key-specific tokens
 			return $this->createAmpacheActionUrl('get_art', $entity->getId(), $type);
 		} else {
-			// Scrutinizer doesn't understand that the if-else above guarantees that getCoverFileId() may be called only on Album or Artist
-			if ($type === 'playlist' || $entity->/** @scrutinizer ignore-call */getCoverFileId()) {
-				$id = $entity->getId();
-				$token = $this->imageService->getToken($type, $id, $this->session->getAmpacheUserId());
-				return $this->urlGenerator->linkToRouteAbsolute('music.ampacheImage.image') . "?object_type=$type&object_id=$id&token=$token";
-			} else {
-				return '';
-			}
+			// The URL is provided even when there is no cover image, matching the original Ampache server where
+			// the property `art` is always a valid URL and clients are expected to check `has_art` to tell whether
+			// it resolves to a real image or to a generated placeholder.
+			$id = $entity->getId();
+			$url = $this->urlGenerator->linkToRouteAbsolute('music.ampacheImage.image') . "?object_type=$type&object_id=$id";
+
+			// The token may be unavailable if the API key used on the handshake has been deleted since. The image
+			// endpoint serves the placeholder without a token, which is a better outcome than a URL with an empty
+			// token, which would always be rejected as invalid.
+			$token = $this->imageService->getToken($type, $id, $this->session->getAmpacheUserId());
+			return ($token !== null) ? "$url&token=$token" : $url;
 		}
 	}
 
@@ -1817,6 +1825,11 @@ class AmpacheController extends ApiController {
 			$album = $track->getAlbum();
 			return ($album !== null && $album->getId() !== null) ? $this->createCoverUrl($album) : '';
 		};
+		// A song carries the art of its album, and so it has art exactly when the album has a cover file
+		$hasArt = function (Track $track) : bool {
+			$album = $track->getAlbum();
+			return ($album !== null && $album->getCoverFileId() !== null);
+		};
 		$renderRef = fn (int $id, string $name) => $this->renderAlbumOrArtistRef($id, $name);
 		$genreKey = $this->genreKey();
 		// In APIv6 JSON format, there is a new property `artists` with an array value
@@ -1824,7 +1837,7 @@ class AmpacheController extends ApiController {
 
 		return [
 			'song' => \array_map(
-				fn ($t) => $t->toAmpacheApi($this->l10n, $createPlayUrl, $createImageUrl, $renderRef, $genreKey, $includeArtists),
+				fn ($t) => $t->toAmpacheApi($this->l10n, $createPlayUrl, $createImageUrl, $hasArt, $renderRef, $genreKey, $includeArtists),
 				$tracks
 			)
 		];
@@ -1834,16 +1847,13 @@ class AmpacheController extends ApiController {
 	 * @param Playlist[] $playlists
 	 */
 	private function renderPlaylists(array $playlists, bool $includeTracks = false) : array {
-		$createImageUrl = function (Playlist $playlist) : string {
-			if ($playlist->getId() === self::ALL_TRACKS_PLAYLIST_ID) {
-				return '';
-			} else {
-				return $this->createCoverUrl($playlist);
-			}
-		};
+		// The "All tracks" pseudo playlist has no counterpart in the database, so the image endpoint could not
+		// resolve it; it's the one playlist for which we have no art URL to give.
+		$isRealPlaylist = fn (Playlist $playlist) => $playlist->getId() !== self::ALL_TRACKS_PLAYLIST_ID;
+		$createImageUrl = fn (Playlist $playlist) => $isRealPlaylist($playlist) ? $this->createCoverUrl($playlist) : '';
 
 		$result = [
-			'playlist' => \array_map(fn ($p) => $p->toAmpacheApi($createImageUrl, $includeTracks), $playlists)
+			'playlist' => \array_map(fn ($p) => $p->toAmpacheApi($createImageUrl, $isRealPlaylist, $includeTracks), $playlists)
 		];
 
 		// annoyingly, the structure of the included tracks is quite different in JSON compared to XML

--- a/lib/Db/Playlist.php
+++ b/lib/Db/Playlist.php
@@ -115,7 +115,7 @@ class Playlist extends Entity {
 		];
 	}
 
-	public function toAmpacheApi(callable $createImageUrl, bool $includeTracks) : array {
+	public function toAmpacheApi(callable $createImageUrl, callable $hasArt, bool $includeTracks) : array {
 		$result = [
 			'id'    => (string)$this->getId(),
 			'name'  => $this->getName(),
@@ -133,7 +133,7 @@ class Playlist extends Entity {
 			'last_update'     => \strtotime($this->getUpdated() ?? ''),
 			'md5'             => $this->getTrackIdsHash()
 		];
-		$result['has_art'] = !empty($result['art']);
+		$result['has_art'] = $hasArt($this);
 
 		if ($includeTracks) {
 			$ids = $this->getTrackIdsAsArray();

--- a/lib/Db/Track.php
+++ b/lib/Db/Track.php
@@ -230,6 +230,7 @@ class Track extends Entity {
 			IL10N $l10n,
 			callable $createPlayUrl,
 			callable $createImageUrl,
+			callable $hasArt,
 			callable $renderAlbumOrArtistRef,
 			string $genreKey,
 			bool $includeArtists) : array {
@@ -275,7 +276,7 @@ class Track extends Entity {
 			'r128_track_gain'       => null,
 		];
 
-		$result['has_art'] = !empty($result['art']);
+		$result['has_art'] = $hasArt($this);
 
 		$genreId = $this->getGenreId();
 		if ($genreId !== null) {

--- a/lib/Service/Scanner.php
+++ b/lib/Service/Scanner.php
@@ -134,18 +134,40 @@ class Scanner extends PublicEmitter {
 	}
 
 	private function updateImage(File $file, string $userId) : void {
-		$coverFileId = $file->getId();
-		$parentFolderId = $file->getParent()->getId();
-		if ($this->albumBusinessLayer->updateFolderCover($coverFileId, $parentFolderId)) {
-			$this->logger->debug('updateImage - the image was set as cover for some album(s)');
-			$this->cache->remove($userId, 'collection');
-		}
-
+		// Resolve the artist covers first, as whether this image depicts an artist decides if it may also
+		// be used as the album cover of the containing folder.
 		$artistIds = $this->artistBusinessLayer->updateCover($file, $userId, $this->userL10N($userId));
 		foreach ($artistIds as $artistId) {
 			$this->logger->debug("updateImage - the image was set as cover for the artist $artistId");
 			$this->coverService->removeArtistCoverFromCache($artistId, $userId);
 		}
+
+		// An image named after an artist is a photo of that artist, and letting it double as the album cover
+		// is what makes an uploaded artist photo look like it replaced the cover. Use it for the album only
+		// when the folder provides no other image, as having no album cover at all is the worse outcome.
+		if (empty($artistIds) || !self::folderHasOtherImage($file)) {
+			$coverFileId = $file->getId();
+			$parentFolderId = $file->getParent()->getId();
+			if ($this->albumBusinessLayer->updateFolderCover($coverFileId, $parentFolderId)) {
+				$this->logger->debug('updateImage - the image was set as cover for some album(s)');
+				$this->cache->remove($userId, 'collection');
+			}
+		} else {
+			$this->logger->debug('updateImage - artist image not used as album cover, the folder has other images');
+		}
+	}
+
+	/**
+	 * Check whether the parent folder of the given image contains at least one other image file
+	 */
+	private static function folderHasOtherImage(File $file) : bool {
+		foreach ($file->getParent()->getDirectoryListing() as $node) {
+			if ($node instanceof File && $node->getId() !== $file->getId()
+					&& StringUtil::startsWith($node->getMimeType(), 'image')) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
* An image file named after an artist no longer doubles as the cover of the album in the same folder, unless the folder has no other image. [#102](https://github.com/nc-music/music/issues/102)
* Property `art` is now always a valid URL like on the original Ampache server, and the clients should use the property `has_art` to tell whether it resolves to a real image
* Art URL was broken if the API key used on the handshake had been deleted
* Art fetched with the action `get_art` was not cached by the clients, unlike the art fetched from `image.php` [#102](https://github.com/nc-music/music/issues/102)

Fixes #102