### PR TITLE
Feat/ampache catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 - Ampache API: Actions `player` and `now_playing`, letting a client report its playback state and read it back. Unlike on the original Ampache server, the state is visible only to the user it belongs to
   [#155](https://github.com/nc-music/music/pull/155) @lachlan-00
 - Ampache API: Actions `catalogs` and `catalog`, presenting the library as the two synthetic catalogs `music` and `podcasts` which the action `browse` has always used
-  [#144](https://github.com/nc-music/music/issues/144)
+  [#144](https://github.com/nc-music/music/issues/144) @lachlan-00
 
 ### Changed
 - Ampache API: Reject the deprecated actions `tag`, `tags`, `tag_albums`, `tag_artists`, and `tag_songs` on API versions 5 and 6 like the original Ampache server does, answering with the error 4706 and, on version 6, the HTTP status 410. The actions still work on API version 4, and the renamed `genre` variants are unaffected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Added
 - Support for Nextcloud 35 (tested on rc2)
   [#144](https://github.com/nc-music/music/issues/144)
+  * The action `browse` now identifies the catalogs by these IDs instead of by their names, and accepts the argument `catalog` to narrow the listed children. The names are still accepted wherever an ID is
+  * The action `browse` renders its IDs as strings on the JSON API, matching the original Ampache server, and accepts the type `album_artist` as an alias of `artist`
 - Admin settings UI to setup Last.fm API key and secret without editing `config.php` manually
   [#131](https://github.com/nc-music/music/pull/131) @mattwellss
 - Possibility to configure the default volume with the config.php key `music.default_volume`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Support for Nextcloud 35 (tested on rc2)
+  [#144](https://github.com/nc-music/music/issues/144)
 - Admin settings UI to setup Last.fm API key and secret without editing `config.php` manually
   [#131](https://github.com/nc-music/music/pull/131) @mattwellss
 - Possibility to configure the default volume with the config.php key `music.default_volume`
@@ -47,6 +48,8 @@
     + The same is shown by `occ music:scan`; these files can be scanned with the option `--rescan-old`
 - Ampache API: Actions `player` and `now_playing`, letting a client report its playback state and read it back. Unlike on the original Ampache server, the state is visible only to the user it belongs to
   [#155](https://github.com/nc-music/music/pull/155) @lachlan-00
+- Ampache API: Actions `catalogs` and `catalog`, presenting the library as the two synthetic catalogs `music` and `podcasts` which the action `browse` has always used
+  [#144](https://github.com/nc-music/music/issues/144)
 
 ### Changed
 - Ampache API: Reject the deprecated actions `tag`, `tags`, `tag_albums`, `tag_artists`, and `tag_songs` on API versions 5 and 6 like the original Ampache server does, answering with the error 4706 and, on version 6, the HTTP status 410. The actions still work on API version 4, and the renamed `genre` variants are unaffected

--- a/lib/Controller/AmpacheController.php
+++ b/lib/Controller/AmpacheController.php
@@ -88,6 +88,19 @@ class AmpacheController extends ApiController {
 	private array $namePrefixes;
 
 	public const ALL_TRACKS_PLAYLIST_ID = -1;
+
+	/**
+	 * The app has no catalog concept of its own but the Ampache API requires one, and clients like Amperfy
+	 * use it as the entry point of their directory browsing. The library is therefore presented as two fixed
+	 * synthetic catalogs, matching the split which the action `browse` has always used on its root level.
+	 */
+	public const CATALOG_MUSIC_ID = 1;
+	public const CATALOG_PODCASTS_ID = 2;
+	private const CATALOGS = [
+		self::CATALOG_MUSIC_ID    => ['name' => 'music',    'gather_types' => 'music'],
+		self::CATALOG_PODCASTS_ID => ['name' => 'podcasts', 'gather_types' => 'podcast'],
+	];
+
 	public const API4_VERSION = '4.4.0';
 	public const API5_VERSION = '5.6.0';
 	public const API6_VERSION = '6.8.0';
@@ -301,7 +314,7 @@ class AmpacheController extends ApiController {
 			'live_streams'        => $this->radioStationBusinessLayer->count($user),
 			$genresKey            => $this->genreBusinessLayer->count($user),
 			'videos'              => 0,
-			'catalogs'            => 0,
+			'catalogs'            => \count(self::CATALOGS),
 			'shares'              => 0,
 			'licenses'            => 0,
 			'labels'              => $this->recordLabelBusinessLayer->count($user),
@@ -434,27 +447,27 @@ class AmpacheController extends ApiController {
 		if ($type == 'root') {
 			$catalogId = null;
 			$childType = 'catalog';
-			$children = [
-				['id' => 'music', 'name' => 'music'],
-				['id' => 'podcasts', 'name' => 'podcasts']
-			];
+			$children = \array_map(
+				fn ($id, $catalog) => ['id' => $id, 'name' => $catalog['name']],
+				\array_keys(self::CATALOGS), self::CATALOGS
+			);
 		} else {
 			if ($type == 'catalog') {
-				$catalogId = null;
+				$catalogId = self::resolveCatalogId($filter);
 				$parentId = null;
 
-				switch ($filter) {
-					case 'music':
+				switch ($catalogId) {
+					case self::CATALOG_MUSIC_ID:
 						$childType = 'artist';
 						break;
-					case 'podcasts':
+					case self::CATALOG_PODCASTS_ID:
 						$childType = 'podcast';
 						break;
 					default:
 						throw new AmpacheException("Filter '$filter' is not a valid catalog", 400);
 				}
 			} else {
-				$catalogId = StringUtil::startsWith($type, 'podcast') ? 'podcasts' : 'music';
+				$catalogId = StringUtil::startsWith($type, 'podcast') ? self::CATALOG_PODCASTS_ID : self::CATALOG_MUSIC_ID;
 				$parentId = empty($filter) ? null : (int)$filter;
 
 				switch ($type) {
@@ -485,6 +498,31 @@ class AmpacheController extends ApiController {
 			'child_type'  => $childType,
 			'browse'      => \array_map(fn ($idAndName) => $idAndName + $this->prefixAndBaseName($idAndName['name']), $children)
 		];
+	}
+
+	#[AmpacheAPI]
+	protected function catalogs(?string $filter, int $limit, int $offset = 0) : array {
+		$catalogIds = \array_keys(self::CATALOGS);
+
+		// On the original Ampache server, the filter of this action selects by gather type, not by name
+		if (!empty($filter)) {
+			$catalogIds = \array_values(\array_filter(
+				$catalogIds, fn ($id) => self::CATALOGS[$id]['gather_types'] === $filter));
+		}
+
+		$catalogIds = \array_slice($catalogIds, $offset, $limit);
+
+		return ['catalog' => \array_map(fn ($id) => $this->renderCatalog($id), $catalogIds)];
+	}
+
+	#[AmpacheAPI]
+	protected function catalog(string $filter) : array {
+		$catalogId = self::resolveCatalogId($filter);
+		if ($catalogId === null) {
+			throw new AmpacheException("Catalog $filter not found", 404);
+		}
+
+		return ['catalog' => [$this->renderCatalog($catalogId)]];
 	}
 
 	#[AmpacheAPI]
@@ -2013,6 +2051,49 @@ class AmpacheController extends ApiController {
 	}
 
 	/**
+	 * Map an id or a name of one of our synthetic catalogs to the canonical catalog id. The names are accepted
+	 * because the action `browse` used them as ids before the catalog actions existed, and clients may have
+	 * stored those; they can be dropped once the next major version has been out for a while.
+	 */
+	private static function resolveCatalogId(?string $idOrName) : ?int {
+		foreach (self::CATALOGS as $id => $catalog) {
+			if ($idOrName === (string)$id || $idOrName === $catalog['name']) {
+				return $id;
+			}
+		}
+		return null;
+	}
+
+	private function renderCatalog(int $catalogId) : array {
+		$userId = $this->userId();
+		$isMusic = ($catalogId === self::CATALOG_MUSIC_ID);
+
+		if ($isMusic) {
+			$addTime = $this->library->latestInsertTime($userId);
+			$updateTime = $this->library->latestUpdateTime($userId);
+		} else {
+			$addTime = \max($this->podcastChannelBusinessLayer->latestInsertTime($userId),
+							$this->podcastEpisodeBusinessLayer->latestInsertTime($userId));
+			$updateTime = \max($this->podcastChannelBusinessLayer->latestUpdateTime($userId),
+							$this->podcastEpisodeBusinessLayer->latestUpdateTime($userId));
+		}
+
+		return [
+			'id'             => (string)$catalogId,
+			'name'           => self::CATALOGS[$catalogId]['name'],
+			'type'           => 'local',
+			'gather_types'   => self::CATALOGS[$catalogId]['gather_types'],
+			'enabled'        => true,
+			'last_add'       => $addTime->getTimestamp(),
+			'last_clean'     => \time(), // we don't track the time of the latest removal, see also the action `handshake`
+			'last_update'    => $updateTime->getTimestamp(),
+			'path'           => $isMusic ? $this->librarySettings->getPath($userId) : '',
+			'rename_pattern' => '',
+			'sort_pattern'   => ''
+		];
+	}
+
+	/**
 	 * @param RadioStation[] $stations
 	 */
 	private function renderLiveStreams(array $stations) : array {
@@ -2285,7 +2366,7 @@ class AmpacheController extends ApiController {
 
 		// all 'entity list' kind of responses shall have the (deprecated) total_count element
 		if (\in_array($firstKey, ['song', 'album', 'artist', 'album_artist', 'song_artist',
-			'playlist', 'tag', 'genre', 'podcast', 'podcast_episode', 'live_stream'])) {
+			'playlist', 'tag', 'genre', 'podcast', 'podcast_episode', 'live_stream', 'catalog'])) {
 			$content = ['total_count' => \count($content[$firstKey])] + $content;
 		}
 

--- a/lib/Controller/AmpacheController.php
+++ b/lib/Controller/AmpacheController.php
@@ -442,8 +442,19 @@ class AmpacheController extends ApiController {
 	}
 
 	#[AmpacheAPI]
-	protected function browse(string $type, ?string $filter, ?string $add, ?string $update, int $limit, int $offset = 0) : array {
-		// note: the argument 'catalog' is disregarded in our implementation
+	protected function browse(
+			string $type, ?string $filter, ?string $add, ?string $update, int $limit, int $offset = 0, ?string $catalog = null) : array {
+		// The argument `catalog` narrows the children instead of addressing the parent. Both of our catalogs are
+		// synthetic and each entity type belongs to exactly one of them, so this filter either lets everything
+		// through or excludes everything.
+		$filterCatalogId = null;
+		if (!empty($catalog)) {
+			$filterCatalogId = self::resolveCatalogId($catalog);
+			if ($filterCatalogId === null) {
+				throw new AmpacheException("Catalog '$catalog' not found", 404);
+			}
+		}
+
 		if ($type == 'root') {
 			$catalogId = null;
 			$childType = 'catalog';
@@ -453,7 +464,8 @@ class AmpacheController extends ApiController {
 			);
 		} else {
 			if ($type == 'catalog') {
-				$catalogId = self::resolveCatalogId($filter);
+				// the catalog may be addressed with the argument `catalog` when there is no `filter`
+				$catalogId = self::resolveCatalogId(empty($filter) ? $catalog : $filter);
 				$parentId = null;
 
 				switch ($catalogId) {
@@ -474,7 +486,11 @@ class AmpacheController extends ApiController {
 					case 'podcast':
 						$childType = 'podcast_episode';
 						break;
+					// The original Ampache browses a music catalog with the type `album_artist` while still
+					// reporting the child type as `artist`. We list the artists having albums in any case,
+					// so the two types are equivalent for us.
 					case 'artist':
+					case 'album_artist':
 						$childType = 'album';
 						break;
 					case 'album':
@@ -485,18 +501,29 @@ class AmpacheController extends ApiController {
 				}
 			}
 
-			$businessLayer = $this->getBusinessLayer($childType);
-			[$addMin, $addMax, $updateMin, $updateMax] = self::parseTimeParameters($add, $update);
-			$children = $businessLayer->findAllIdsAndNames(
-				$this->userId(), $this->l10n, $parentId, $limit, $offset, $addMin, $addMax, $updateMin, $updateMax, true);
+			// Each of our entity types belongs to exactly one of the synthetic catalogs, so a request for the
+			// other catalog has nothing to return.
+			if ($filterCatalogId !== null && $type != 'catalog' && $filterCatalogId !== $catalogId) {
+				$children = [];
+			} else {
+				$businessLayer = $this->getBusinessLayer($childType);
+				[$addMin, $addMax, $updateMin, $updateMax] = self::parseTimeParameters($add, $update);
+				$children = $businessLayer->findAllIdsAndNames(
+					$this->userId(), $this->l10n, $parentId, $limit, $offset, $addMin, $addMax, $updateMin, $updateMax, true);
+			}
 		}
 
+		// The original Ampache renders all these IDs as strings, which is visible on the JSON API. A null is
+		// rendered as an empty string, matching its `(string)` casts.
 		return [
-			'catalog_id'  => $catalogId,
-			'parent_id'   => $filter,
+			'catalog_id'  => (string)$catalogId,
+			'parent_id'   => (string)$filter,
 			'parent_type' => $type,
 			'child_type'  => $childType,
-			'browse'      => \array_map(fn ($idAndName) => $idAndName + $this->prefixAndBaseName($idAndName['name']), $children)
+			'browse'      => \array_map(
+				fn ($idAndName) => ['id' => (string)$idAndName['id'], 'name' => $idAndName['name']]
+							+ $this->prefixAndBaseName($idAndName['name']),
+				$children)
 		];
 	}
 

--- a/lib/Controller/AmpacheController.php
+++ b/lib/Controller/AmpacheController.php
@@ -94,11 +94,11 @@ class AmpacheController extends ApiController {
 	 * use it as the entry point of their directory browsing. The library is therefore presented as two fixed
 	 * synthetic catalogs, matching the split which the action `browse` has always used on its root level.
 	 */
-	public const CATALOG_MUSIC_ID = 1;
-	public const CATALOG_PODCASTS_ID = 2;
+	public const CATALOG_MUSIC_ID = 'music';
+	public const CATALOG_PODCASTS_ID = 'podcasts';
 	private const CATALOGS = [
-		self::CATALOG_MUSIC_ID    => ['name' => 'music',    'gather_types' => 'music'],
-		self::CATALOG_PODCASTS_ID => ['name' => 'podcasts', 'gather_types' => 'podcast'],
+		self::CATALOG_MUSIC_ID    => ['name' => 'Music',    'gather_types' => 'music'],
+		self::CATALOG_PODCASTS_ID => ['name' => 'Podcasts', 'gather_types' => 'podcast'],
 	];
 
 	public const API4_VERSION = '4.4.0';
@@ -448,24 +448,21 @@ class AmpacheController extends ApiController {
 		// synthetic and each entity type belongs to exactly one of them, so this filter either lets everything
 		// through or excludes everything.
 		$filterCatalogId = null;
-		if (!empty($catalog)) {
-			$filterCatalogId = self::resolveCatalogId($catalog);
-			if ($filterCatalogId === null) {
-				throw new AmpacheException("Catalog '$catalog' not found", 404);
-			}
+		if (!empty($catalog) && !\array_key_exists($catalog, self::CATALOGS)) {
+			throw new AmpacheException("Catalog '$catalog' not found", 404);
 		}
 
 		if ($type == 'root') {
 			$catalogId = null;
 			$childType = 'catalog';
 			$children = \array_map(
-				fn ($id, $catalog) => ['id' => $id, 'name' => $catalog['name']],
+				fn ($id, $catalogDetails) => ['id' => $id, 'name' => $this->l10n->t($catalogDetails['name'])],
 				\array_keys(self::CATALOGS), self::CATALOGS
 			);
 		} else {
 			if ($type == 'catalog') {
 				// the catalog may be addressed with the argument `catalog` when there is no `filter`
-				$catalogId = self::resolveCatalogId(empty($filter) ? $catalog : $filter);
+				$catalogId = empty($filter) ? $catalog : $filter;
 				$parentId = null;
 
 				switch ($catalogId) {
@@ -476,7 +473,7 @@ class AmpacheController extends ApiController {
 						$childType = 'podcast';
 						break;
 					default:
-						throw new AmpacheException("Filter '$filter' is not a valid catalog", 400);
+						throw new AmpacheException("Filter '$catalogId' is not a valid catalog", 400);
 				}
 			} else {
 				$catalogId = StringUtil::startsWith($type, 'podcast') ? self::CATALOG_PODCASTS_ID : self::CATALOG_MUSIC_ID;
@@ -503,7 +500,7 @@ class AmpacheController extends ApiController {
 
 			// Each of our entity types belongs to exactly one of the synthetic catalogs, so a request for the
 			// other catalog has nothing to return.
-			if ($filterCatalogId !== null && $type != 'catalog' && $filterCatalogId !== $catalogId) {
+			if ($catalog !== null && $type != 'catalog' && $catalog !== $catalogId) {
 				$children = [];
 			} else {
 				$businessLayer = $this->getBusinessLayer($childType);
@@ -544,12 +541,11 @@ class AmpacheController extends ApiController {
 
 	#[AmpacheAPI]
 	protected function catalog(string $filter) : array {
-		$catalogId = self::resolveCatalogId($filter);
-		if ($catalogId === null) {
+		if (!\array_key_exists($filter, self::CATALOGS)) {
 			throw new AmpacheException("Catalog $filter not found", 404);
 		}
 
-		return ['catalog' => [$this->renderCatalog($catalogId)]];
+		return ['catalog' => [$this->renderCatalog($filter)]];
 	}
 
 	#[AmpacheAPI]
@@ -2077,21 +2073,7 @@ class AmpacheController extends ApiController {
 		];
 	}
 
-	/**
-	 * Map an id or a name of one of our synthetic catalogs to the canonical catalog id. The names are accepted
-	 * because the action `browse` used them as ids before the catalog actions existed, and clients may have
-	 * stored those; they can be dropped once the next major version has been out for a while.
-	 */
-	private static function resolveCatalogId(?string $idOrName) : ?int {
-		foreach (self::CATALOGS as $id => $catalog) {
-			if ($idOrName === (string)$id || $idOrName === $catalog['name']) {
-				return $id;
-			}
-		}
-		return null;
-	}
-
-	private function renderCatalog(int $catalogId) : array {
+	private function renderCatalog(string $catalogId) : array {
 		$userId = $this->userId();
 		$isMusic = ($catalogId === self::CATALOG_MUSIC_ID);
 
@@ -2106,8 +2088,8 @@ class AmpacheController extends ApiController {
 		}
 
 		return [
-			'id'             => (string)$catalogId,
-			'name'           => self::CATALOGS[$catalogId]['name'],
+			'id'             => $catalogId,
+			'name'           => $this->l10n->t(self::CATALOGS[$catalogId]['name']),
 			'type'           => 'local',
 			'gather_types'   => self::CATALOGS[$catalogId]['gather_types'],
 			'enabled'        => true,

--- a/tests/features/Ampache/Browse.feature
+++ b/tests/features/Ampache/Browse.feature
@@ -13,16 +13,16 @@ Feature: Ampache API - Browse
     And I request the "browse" resource
     Then the element "/root/child_type" should be "catalog"
     And there should be 2 "/root/browse" elements
-    And the element "/root/browse[1]/name" should be "music"
-    And the element "/root/browse[2]/name" should be "podcasts"
+    And the element "/root/browse[1]/name" should be "Music"
+    And the element "/root/browse[2]/name" should be "Podcasts"
 
 
   Scenario: A music catalog is browsed into artists
     Given I am logged in with API version "6.6.0"
     When I specify the parameter "type" with value "catalog"
-    And I specify the parameter "filter" with value "1"
+    And I specify the parameter "filter" with value "music"
     And I request the "browse" resource
-    Then the element "/root/catalog_id" should be "1"
+    Then the element "/root/catalog_id" should be "music"
     And the element "/root/child_type" should be "artist"
     And there should be 3 "/root/browse" elements
 
@@ -30,7 +30,7 @@ Feature: Ampache API - Browse
   Scenario: A podcast catalog is browsed into podcasts
     Given I am logged in with API version "6.6.0"
     When I specify the parameter "type" with value "catalog"
-    And I specify the parameter "filter" with value "2"
+    And I specify the parameter "filter" with value "podcasts"
     And I request the "browse" resource
     Then the element "/root/child_type" should be "podcast"
 
@@ -38,7 +38,7 @@ Feature: Ampache API - Browse
   Scenario: An artist is browsed into albums
     Given I am logged in with API version "6.6.0"
     When I specify the parameter "type" with value "catalog"
-    And I specify the parameter "filter" with value "1"
+    And I specify the parameter "filter" with value "music"
     And I request the "browse" resource
     And I store the "@id" of the first result as "artistId"
     And I specify the parameter "type" with value "artist"
@@ -51,7 +51,7 @@ Feature: Ampache API - Browse
   Scenario: The type album_artist is an accepted alias of artist
     Given I am logged in with API version "6.6.0"
     When I specify the parameter "type" with value "catalog"
-    And I specify the parameter "filter" with value "1"
+    And I specify the parameter "filter" with value "music"
     And I request the "browse" resource
     And I store the "@id" of the first result as "artistId"
     And I specify the parameter "type" with value "album_artist"
@@ -65,12 +65,12 @@ Feature: Ampache API - Browse
   Scenario: The catalog of the browsed type lets the children through
     Given I am logged in with API version "6.6.0"
     When I specify the parameter "type" with value "catalog"
-    And I specify the parameter "filter" with value "1"
+    And I specify the parameter "filter" with value "music"
     And I request the "browse" resource
     And I store the "@id" of the first result as "artistId"
     And I specify the parameter "type" with value "artist"
     And I specify the parameter "filter" with value ":artistId"
-    And I specify the parameter "catalog" with value "1"
+    And I specify the parameter "catalog" with value "music"
     And I request the "browse" resource
     Then the element "/root/browse[1]/name" should be "The Butcher's Ballroom"
 
@@ -78,12 +78,12 @@ Feature: Ampache API - Browse
   Scenario: The other catalog excludes all the children
     Given I am logged in with API version "6.6.0"
     When I specify the parameter "type" with value "catalog"
-    And I specify the parameter "filter" with value "1"
+    And I specify the parameter "filter" with value "music"
     And I request the "browse" resource
     And I store the "@id" of the first result as "artistId"
     And I specify the parameter "type" with value "artist"
     And I specify the parameter "filter" with value ":artistId"
-    And I specify the parameter "catalog" with value "2"
+    And I specify the parameter "catalog" with value "podcasts"
     And I request the "browse" resource
     Then the element "/root/child_type" should be "album"
     And there should be 0 "/root/browse" elements
@@ -109,9 +109,9 @@ Feature: Ampache API - Browse
   Scenario: The IDs are rendered as strings in the JSON format
     Given I am logged in with API version "6.6.0"
     When I specify the parameter "type" with value "catalog"
-    And I specify the parameter "filter" with value "1"
+    And I specify the parameter "filter" with value "music"
     And I request the "browse" resource in JSON format
-    Then the JSON path "catalog_id" should be the string "1"
-    And the JSON path "parent_id" should be the string "1"
+    Then the JSON path "catalog_id" should be the string "music"
+    And the JSON path "parent_id" should be the string "music"
     And the JSON path "browse.0.id" should be a string
     And the JSON path "browse.0.name" should be "Diablo Swing Orchestra"

--- a/tests/features/Ampache/Browse.feature
+++ b/tests/features/Ampache/Browse.feature
@@ -1,0 +1,117 @@
+Feature: Ampache API - Browse
+  In order to navigate my library the way a directory browser does
+  As a user
+  I need to be able to walk the catalog, artist and album hierarchy one level at a time
+
+  Note: the two catalogs are synthetic and each entity type belongs to exactly one of them, so the argument
+  `catalog` either lets everything through or excludes everything.
+
+
+  Scenario: The root lists the catalogs
+    Given I am logged in with API version "6.6.0"
+    When I specify the parameter "type" with value "root"
+    And I request the "browse" resource
+    Then the element "/root/child_type" should be "catalog"
+    And there should be 2 "/root/browse" elements
+    And the element "/root/browse[1]/name" should be "music"
+    And the element "/root/browse[2]/name" should be "podcasts"
+
+
+  Scenario: A music catalog is browsed into artists
+    Given I am logged in with API version "6.6.0"
+    When I specify the parameter "type" with value "catalog"
+    And I specify the parameter "filter" with value "1"
+    And I request the "browse" resource
+    Then the element "/root/catalog_id" should be "1"
+    And the element "/root/child_type" should be "artist"
+    And there should be 3 "/root/browse" elements
+
+
+  Scenario: A podcast catalog is browsed into podcasts
+    Given I am logged in with API version "6.6.0"
+    When I specify the parameter "type" with value "catalog"
+    And I specify the parameter "filter" with value "2"
+    And I request the "browse" resource
+    Then the element "/root/child_type" should be "podcast"
+
+
+  Scenario: An artist is browsed into albums
+    Given I am logged in with API version "6.6.0"
+    When I specify the parameter "type" with value "catalog"
+    And I specify the parameter "filter" with value "1"
+    And I request the "browse" resource
+    And I store the "@id" of the first result as "artistId"
+    And I specify the parameter "type" with value "artist"
+    And I specify the parameter "filter" with value ":artistId"
+    And I request the "browse" resource
+    Then the element "/root/child_type" should be "album"
+    And the element "/root/browse[1]/name" should be "The Butcher's Ballroom"
+
+
+  Scenario: The type album_artist is an accepted alias of artist
+    Given I am logged in with API version "6.6.0"
+    When I specify the parameter "type" with value "catalog"
+    And I specify the parameter "filter" with value "1"
+    And I request the "browse" resource
+    And I store the "@id" of the first result as "artistId"
+    And I specify the parameter "type" with value "album_artist"
+    And I specify the parameter "filter" with value ":artistId"
+    And I request the "browse" resource
+    Then the element "/root/parent_type" should be "album_artist"
+    And the element "/root/child_type" should be "album"
+    And the element "/root/browse[1]/name" should be "The Butcher's Ballroom"
+
+
+  Scenario: The catalog of the browsed type lets the children through
+    Given I am logged in with API version "6.6.0"
+    When I specify the parameter "type" with value "catalog"
+    And I specify the parameter "filter" with value "1"
+    And I request the "browse" resource
+    And I store the "@id" of the first result as "artistId"
+    And I specify the parameter "type" with value "artist"
+    And I specify the parameter "filter" with value ":artistId"
+    And I specify the parameter "catalog" with value "1"
+    And I request the "browse" resource
+    Then the element "/root/browse[1]/name" should be "The Butcher's Ballroom"
+
+
+  Scenario: The other catalog excludes all the children
+    Given I am logged in with API version "6.6.0"
+    When I specify the parameter "type" with value "catalog"
+    And I specify the parameter "filter" with value "1"
+    And I request the "browse" resource
+    And I store the "@id" of the first result as "artistId"
+    And I specify the parameter "type" with value "artist"
+    And I specify the parameter "filter" with value ":artistId"
+    And I specify the parameter "catalog" with value "2"
+    And I request the "browse" resource
+    Then the element "/root/child_type" should be "album"
+    And there should be 0 "/root/browse" elements
+
+
+  Scenario: A catalog which does not exist
+    Given I am logged in with API version "6.6.0"
+    When I specify the parameter "type" with value "artist"
+    And I specify the parameter "filter" with value "1"
+    And I specify the parameter "catalog" with value "99"
+    And I request the "browse" resource expecting an error
+    Then the error code should be "4704" of type "system"
+
+
+  Scenario: An unsupported type
+    Given I am logged in with API version "6.6.0"
+    When I specify the parameter "type" with value "album_disk"
+    And I specify the parameter "filter" with value "1"
+    And I request the "browse" resource expecting an error
+    Then the error code should be "4710" of type "system"
+
+
+  Scenario: The IDs are rendered as strings in the JSON format
+    Given I am logged in with API version "6.6.0"
+    When I specify the parameter "type" with value "catalog"
+    And I specify the parameter "filter" with value "1"
+    And I request the "browse" resource in JSON format
+    Then the JSON path "catalog_id" should be the string "1"
+    And the JSON path "parent_id" should be the string "1"
+    And the JSON path "browse.0.id" should be a string
+    And the JSON path "browse.0.name" should be "Diablo Swing Orchestra"

--- a/tests/features/Ampache/Catalogs.feature
+++ b/tests/features/Ampache/Catalogs.feature
@@ -10,9 +10,9 @@ Feature: Ampache API - Catalogs
     Given I am logged in with an auth token
     When I request the "catalogs" resource
     Then I should get:
-      | @id | name     | type  | gather_types |
-      | 1   | music    | local | music        |
-      | 2   | podcasts | local | podcast      |
+      | @id      | name     | type  | gather_types |
+      | music    | Music    | local | music        |
+      | podcasts | Podcasts | local | podcast      |
 
 
   Scenario: List catalogs filtered by gather type
@@ -21,7 +21,7 @@ Feature: Ampache API - Catalogs
     And I request the "catalogs" resource
     Then I should get:
       | @id | name     | type  | gather_types |
-      | 2   | podcasts | local | podcast      |
+      | podcasts | Podcasts | local | podcast      |
 
 
   Scenario: List catalogs with a gather type which we have no catalog for
@@ -37,32 +37,23 @@ Feature: Ampache API - Catalogs
     When I specify the parameter "limit" with value "1"
     And I request the "catalogs" resource
     Then I should get:
-      | @id | name  | type  | gather_types |
-      | 1   | music | local | music        |
+      | @id   | name  | type  | gather_types |
+      | music | Music | local | music        |
 
 
   Scenario: Get a single catalog by id
     Given I am logged in with an auth token
-    When I specify the parameter "filter" with value "2"
+    When I specify the parameter "filter" with value "podcasts"
     And I request the "catalog" resource
     Then I should get:
-      | @id | name     | type  | gather_types |
-      | 2   | podcasts | local | podcast      |
-
-
-  Scenario: Get a single catalog by the legacy name used by the browse action
-    Given I am logged in with an auth token
-    When I specify the parameter "filter" with value "music"
-    And I request the "catalog" resource
-    Then I should get:
-      | @id | name  | type  | gather_types |
-      | 1   | music | local | music        |
+      | @id      | name     | type  | gather_types |
+      | podcasts | Podcasts | local | podcast      |
 
 
   Scenario: List all catalogs in the JSON format on API version 6
     Given I am logged in with API version "6.6.0"
     When I request the "catalogs" resource in JSON format
     Then I should get JSON:
-      | id | name     | type  | gather_types | enabled | rename_pattern | sort_pattern |
-      | 1  | music    | local | music        | 1       |                |              |
-      | 2  | podcasts | local | podcast      | 1       |                |              |
+      | id       | name     | type  | gather_types | enabled | rename_pattern | sort_pattern |
+      | music    | Music    | local | music        | 1       |                |              |
+      | podcasts | Podcasts | local | podcast      | 1       |                |              |

--- a/tests/features/Ampache/Catalogs.feature
+++ b/tests/features/Ampache/Catalogs.feature
@@ -1,0 +1,68 @@
+Feature: Ampache API - Catalogs
+  In order to browse my collection with a client which navigates by catalog
+  As a user
+  I need to be able to list the catalogs of the library
+
+  Note: the id is an attribute rather than a child element in the XML format, hence the "@id" columns.
+
+
+  Scenario: List all catalogs
+    Given I am logged in with an auth token
+    When I request the "catalogs" resource
+    Then I should get:
+      | @id | name     | type  | gather_types |
+      | 1   | music    | local | music        |
+      | 2   | podcasts | local | podcast      |
+
+
+  Scenario: List catalogs filtered by gather type
+    Given I am logged in with an auth token
+    When I specify the parameter "filter" with value "podcast"
+    And I request the "catalogs" resource
+    Then I should get:
+      | @id | name     | type  | gather_types |
+      | 2   | podcasts | local | podcast      |
+
+
+  Scenario: List catalogs with a gather type which we have no catalog for
+    Given I am logged in with an auth token
+    When I specify the parameter "filter" with value "video"
+    And I request the "catalogs" resource
+    Then I should get:
+      | @id | name | type | gather_types |
+
+
+  Scenario: List one catalog with limit
+    Given I am logged in with an auth token
+    When I specify the parameter "limit" with value "1"
+    And I request the "catalogs" resource
+    Then I should get:
+      | @id | name  | type  | gather_types |
+      | 1   | music | local | music        |
+
+
+  Scenario: Get a single catalog by id
+    Given I am logged in with an auth token
+    When I specify the parameter "filter" with value "2"
+    And I request the "catalog" resource
+    Then I should get:
+      | @id | name     | type  | gather_types |
+      | 2   | podcasts | local | podcast      |
+
+
+  Scenario: Get a single catalog by the legacy name used by the browse action
+    Given I am logged in with an auth token
+    When I specify the parameter "filter" with value "music"
+    And I request the "catalog" resource
+    Then I should get:
+      | @id | name  | type  | gather_types |
+      | 1   | music | local | music        |
+
+
+  Scenario: List all catalogs in the JSON format on API version 6
+    Given I am logged in with API version "6.6.0"
+    When I request the "catalogs" resource in JSON format
+    Then I should get JSON:
+      | id | name     | type  | gather_types | enabled | rename_pattern | sort_pattern |
+      | 1  | music    | local | music        | 1       |                |              |
+      | 2  | podcasts | local | podcast      | 1       |                |              |

--- a/tests/features/bootstrap/AmpacheContext.php
+++ b/tests/features/bootstrap/AmpacheContext.php
@@ -46,6 +46,7 @@ class AmpacheContext implements Context, SnippetAcceptingContext {
 		'songs'              => 'song',
 		'catalogs'           => 'catalog',
 		'catalog'            => 'catalog',
+		'browse'             => 'browse',
 		'live_streams'       => 'live_stream',
 		'live_stream'        => 'live_stream',
 		'live_stream_create' => 'live_stream',
@@ -245,6 +246,110 @@ class AmpacheContext implements Context, SnippetAcceptingContext {
 		if ($expectedCount !== $actualCount) {
 			throw new Exception('Not all elements are in the result set - ' . $actualCount
 								. ' does not match the expected ' . $expectedCount . PHP_EOL . \json_encode($this->json));
+		}
+	}
+
+	/**
+	 * Assert a single value of the XML response, addressed with an absolute XPath. This is what makes the
+	 * nested responses testable, as the table-based steps can only describe a flat list of elements.
+	 *
+	 * @Then the element :xpath should be :expected
+	 */
+	public function theElementShouldBe($xpath, $expected) {
+		$found = $this->xml->xpath($xpath);
+		if ($found === false || empty($found)) {
+			throw new Exception("Nothing found with the XPath '$xpath'" . PHP_EOL . $this->xml->asXML());
+		}
+		$actual = $found[0]->__toString();
+		if ($actual !== $expected) {
+			throw new Exception("Expected '$expected' at '$xpath' but got '$actual'" . PHP_EOL . $this->xml->asXML());
+		}
+	}
+
+	/**
+	 * @Then there should be :count :xpath elements
+	 */
+	public function thereShouldBeElements($count, $xpath) {
+		$found = $this->xml->xpath($xpath);
+		$actual = ($found === false) ? 0 : \count($found);
+		if ($actual !== (int)$count) {
+			throw new Exception("Expected $count elements at '$xpath' but got $actual"
+								. PHP_EOL . $this->xml->asXML());
+		}
+	}
+
+	/**
+	 * Assert a single value of the JSON response, addressed with a dot-separated path where the steps are
+	 * either object keys or numeric array indices.
+	 *
+	 * @Then the JSON path :path should be :expected
+	 */
+	public function theJsonPathShouldBe($path, $expected) {
+		$actual = $this->jsonValueAt($path);
+		// the feature files always carry strings, so compare loosely to accept ints and bools as well
+		if ($actual != $expected) {
+			throw new Exception("Expected '$expected' at '$path' but got '"
+								. \var_export($actual, true) . "'" . PHP_EOL . \json_encode($this->json));
+		}
+	}
+
+	/**
+	 * Walk a dot-separated path within the latest JSON response
+	 * @return mixed
+	 */
+	private function jsonValueAt(string $path) {
+		$value = $this->json;
+		foreach (\explode('.', $path) as $step) {
+			if (!\is_array($value) || !\array_key_exists($step, $value)) {
+				throw new Exception("Nothing found at the path '$path', stopped at '$step'"
+									. PHP_EOL . \json_encode($this->json));
+			}
+			$value = $value[$step];
+		}
+		return $value;
+	}
+
+	/**
+	 * Like the step above but strict about the JSON type, for the properties which the original Ampache
+	 * renders as strings even when the value is numeric.
+	 *
+	 * @Then the JSON path :path should be the string :expected
+	 */
+	public function theJsonPathShouldBeTheString($path, $expected) {
+		$actual = $this->jsonValueAt($path);
+		if (!\is_string($actual)) {
+			throw new Exception("Expected a string at '$path' but got " . \gettype($actual)
+								. ' ' . \var_export($actual, true) . PHP_EOL . \json_encode($this->json));
+		}
+		if ($actual !== $expected) {
+			throw new Exception("Expected '$expected' at '$path' but got '$actual'"
+								. PHP_EOL . \json_encode($this->json));
+		}
+	}
+
+	/**
+	 * Assert the JSON type alone, for the properties whose value depends on the installation.
+	 *
+	 * @Then the JSON path :path should be a string
+	 */
+	public function theJsonPathShouldBeAString($path) {
+		$actual = $this->jsonValueAt($path);
+		if (!\is_string($actual)) {
+			throw new Exception("Expected a string at '$path' but got " . \gettype($actual)
+								. ' ' . \var_export($actual, true) . PHP_EOL . \json_encode($this->json));
+		}
+	}
+
+	/**
+	 * Worded so that it cannot also match the generic step above, which would make the match ambiguous.
+	 *
+	 * @Then the JSON path :path should have no value
+	 */
+	public function theJsonPathShouldBeNull($path) {
+		$actual = $this->jsonValueAt($path);
+		if ($actual !== null) {
+			throw new Exception("Expected null at '$path' but got " . \gettype($actual)
+								. ' ' . \var_export($actual, true) . PHP_EOL . \json_encode($this->json));
 		}
 	}
 


### PR DESCRIPTION
Supporting top-level folders as catalogs would require significant rework, so this PR takes a different approach that gives clients a functional entry point into the library while remaining compatible with existing behaviour.

The change has two parts. First, catalogs/catalog now expose two synthetic catalogs, music and podcasts, mirroring how browse has always presented the library root. Clients such as Amperfy rely on catalogs as their browsing entry point and cannot navigate the library without them (fixes #144). Second, API major version 8 adds support for Ampache's standard folders action, allowing clients to traverse the real library folder structure one level at a time.

## Catalogs

While Nextcloud does not have Ampache's catalog model, the synthetic music and podcasts catalogs behave the same way and use the same field set as a native Ampache server.

The podcasts catalog reports type=local because Ampache stores downloaded podcast episodes within the catalog itself. Nextcloud does not; playback either redirects the client to the publisher or proxies the stream. In Ampache, remote specifically represents another Ampache server. The two synthetic catalogs are distinguished by their path, which is documented where the value is assigned.

Podcasts have been available from the root browse action for years, and that remains the only path available to browse-driven clients.

## API 8 Folder Browsing

apiMajorVersion() now supports versions 4, 5, 6 and 8. Version 7 falls back to 6, while anything higher than 8 is clamped to 8.

API 8 is identical to API 6 except for the new folders action, which follows Ampache's Folders8Method implementation:

* filter accepts a folder ID or path, with /, -1 or no value representing the library root
* exact=0 performs loose path matching
* add and update filter child tracks by creation or modification time
* Responses return folder metadata and a mixed list of child folders and songs

The root always reports ID -1, matching upstream behaviour, with top-level folders reporting parent=-1 so clients can navigate both down and back up the tree.

## Why Not Use Root Folders as Catalogs?

Ampache treats catalogs as content containers and folders as a separate abstraction. Folders already hold a catalog reference, and API 8 introduces catalog-based filtering on browse. Treating every top-level folder as its own catalog would require supporting an unknown number of dynamically generated catalogs inside an existing catalog root, significantly increasing complexity without solving a real client problem.

## Shared Code

Two shared changes also affect the Subsonic API:

* FileSystemService::resolveFolderPath() extracts the existing recursive path-resolution logic so both Subsonic and Ampache folder browsing can reuse it
* TrackMapper::findAllByFolder() now supports optional timestamp filtering, applied in SQL through the existing formatTimestampConditions() helper
* findAllFolders() gained an opt-in $withPaths parameter so callers only resolve folder paths when required, avoiding unnecessary work for endpoints that serialise results directly.

## Testing

Coverage increased. New test suites cover:

* Ampache folder browsing, paging, filtering and API version dispatch
* API version negotiation, including previously untested 7→6 and >8→8 behaviour
* Subsonic folder navigation and song path generation
* Subsonic error handling, including its protocol requirement to return errors within HTTP 200 responses
* Browse tests extended

The test harness was extended with generic JSON and XML assertions required for nested folder responses and Subsonic protocol validation.

To verify the coverage, production code was intentionally broken in several places. All changes were validated against a real Nextcloud instance via docker, with phpstan clean and all unit tests passing.

## Known Limitations

* cond and sort parameters are accepted but ignored by folders
* add and update filters apply only to tracks, not folders
* Multi-level folder traversal is verified manually but not yet covered by CI, as the shared test fixture currently contains a completely flat directory structure