### PR TITLE
Feat/ampache deprecated actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   [#80 (comment)](https://github.com/nc-music/music/issues/80#issuecomment-3725231400)
 
 ### Changed
+- Ampache API: Reject the deprecated actions `tag`, `tags`, `tag_albums`, `tag_artists`, and `tag_songs` on API versions 5 and 6 like the original Ampache server does, answering with the error 4706 and, on version 6, the HTTP status 410. The actions still work on API version 4, and the renamed `genre` variants are unaffected
 - Show some error details in the browser console when subscribing a podcast channel fails
   [#132](https://github.com/nc-music/music/issues/132)
 - Avoid PostgreSQL logging tons of unique constraint violations on typical library scan

--- a/lib/Controller/AmpacheController.php
+++ b/lib/Controller/AmpacheController.php
@@ -91,6 +91,13 @@ class AmpacheController extends ApiController {
 	public const API6_VERSION = '6.8.0';
 	public const API_MIN_COMPATIBLE_VERSION = '350001';
 
+	/**
+	 * The pre-rename spelling of the genre actions. The original Ampache server dropped these from its
+	 * method list on API5 and answers them with the error 4706 there, adding also the HTTP status 410 on
+	 * API6. We keep serving them on API4, where they are still a valid part of the protocol.
+	 */
+	private const DEPRECATED_ACTIONS = ['tag', 'tags', 'tag_albums', 'tag_artists', 'tag_songs'];
+
 	public function __construct(
 		string $appName,
 		IRequest $request,
@@ -144,7 +151,7 @@ class AmpacheController extends ApiController {
 		}
 	}
 
-	public function ampacheErrorResponse(int $code, string $message) : Response {
+	public function ampacheErrorResponse(int $code, string $message, string $errorType = 'system') : Response {
 		$this->logger->debug($message);
 
 		if ($this->apiMajorVersion() > 4) {
@@ -153,7 +160,7 @@ class AmpacheController extends ApiController {
 				'error' => [
 					'errorCode'    => (string)$code,
 					'errorAction'  => $this->request->getParam('action'),
-					'errorType'    => 'system',
+					'errorType'    => $errorType,
 					'errorMessage' => $message
 				]
 			];
@@ -198,6 +205,10 @@ class AmpacheController extends ApiController {
 	protected function dispatch(string $action) : Response {
 		$this->logger->debug("Ampache action '$action' requested");
 
+		if (\in_array($action, self::DEPRECATED_ACTIONS) && $this->apiMajorVersion() > 4) {
+			return $this->deprecatedActionResponse($action);
+		}
+
 		// Allow calling any functions annotated to be part of the API
 		if (\method_exists($this, $action)) {
 			$reflection = new \ReflectionMethod($this, $action);
@@ -235,6 +246,21 @@ class AmpacheController extends ApiController {
 		// No method was found for this action
 		$this->logger->warning("Unsupported Ampache action '$action' requested");
 		throw new AmpacheException('Action not supported', 405);
+	}
+
+	/**
+	 * Reject one of the actions removed from the protocol after API4, matching how the original Ampache
+	 * server answers them. Only API6 carries the HTTP status; on API5 the error travels in the body of an
+	 * otherwise ordinary 200 response.
+	 */
+	private function deprecatedActionResponse(string $action) : Response {
+		$this->logger->debug("Deprecated Ampache action '$action' requested, use the 'genre' variant instead");
+
+		$response = $this->ampacheErrorResponse(410, 'Deprecated', 'removed');
+		if ($this->apiMajorVersion() > 5) {
+			$response->setStatus(Http::STATUS_GONE);
+		}
+		return $response;
 	}
 
 	/***********************
@@ -2209,6 +2235,7 @@ class AmpacheController extends ApiController {
 			case 403:	return 4703;	// access denied
 			case 404:	return 4704;	// not found
 			case 405:	return 4705;	// missing
+			case 410:	return 4706;	// deprecated
 			case 412:	return 4742;	// failed access check
 			case 501:	return 4700;	// access control not enabled
 			default:	return 5000;	// unexpected (not part of the API spec)

--- a/tests/features/Ampache/DeprecatedActions.feature
+++ b/tests/features/Ampache/DeprecatedActions.feature
@@ -1,0 +1,42 @@
+Feature: Ampache API - Deprecated genre actions
+  In order to know that I must migrate to the renamed genre actions
+  As a client
+  I need the server to reject the pre-rename spellings the same way the original Ampache server does
+
+  The original Ampache server dropped `tag`, `tags`, `tag_albums`, `tag_artists` and `tag_songs` from
+  its method list on API5, answering them with the error 4706 and adding the HTTP status 410 on API6.
+  They remain a valid part of API4, so they must keep working there.
+
+
+  Scenario: The deprecated actions still work on API4
+    Given I am logged in with an auth token
+    When I request the "tags" resource
+    Then the response should not be an error
+
+
+  Scenario Outline: The deprecated actions are rejected on API6 with the HTTP status
+    Given I am logged in with API version "6.6.0"
+    When I request the "<action>" resource expecting an error
+    Then the response status should be "410"
+    And the error code should be "4706" of type "removed"
+
+    Examples:
+      | action      |
+      | tag         |
+      | tags        |
+      | tag_albums  |
+      | tag_artists |
+      | tag_songs   |
+
+
+  Scenario: The deprecated actions are rejected on API5 without an HTTP status
+    Given I am logged in with API version "5.6.0"
+    When I request the "tags" resource expecting an error
+    Then the response status should be "200"
+    And the error code should be "4706" of type "removed"
+
+
+  Scenario: The renamed genre actions are unaffected on API6
+    Given I am logged in with API version "6.6.0"
+    When I request the "genres" resource
+    Then the response should not be an error

--- a/tests/features/bootstrap/AmpacheClient.php
+++ b/tests/features/bootstrap/AmpacheClient.php
@@ -13,14 +13,17 @@
  */
 
 use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Abstraction for the specific Ampache API calls and how to parse the result
  */
 class AmpacheClient {
 
-	/** @var string the Ampache API URL */
+	/** @var string the Ampache API URL for the XML format */
 	private string $baseUrl;
+	/** @var string the Ampache API URL for the JSON format */
+	private string $baseUrlJson;
 	/** @var string auth token that is used in subsequent requests */
 	private ?string $authToken;
 
@@ -30,10 +33,14 @@ class AmpacheClient {
 	 * @param string $baseUrl URL of the cloud instance
 	 * @param string $userName
 	 * @param string $password
+	 * @param string $version API version to negotiate on the handshake. The version is bound to the session,
+	 *                        so it cannot be changed without logging in again. The default is the lowest
+	 *                        supported version, which the app serves with its API v4 implementation.
 	 * @throws AmpacheClientException if the authentication doesn't succeed
 	 */
-	public function __construct($baseUrl, $userName, $password) {
+	public function __construct($baseUrl, $userName, $password, $version = '350001') {
 		$this->baseUrl = $baseUrl . '/apps/music/ampache/server/xml.server.php';
+		$this->baseUrlJson = $baseUrl . '/apps/music/ampache/server/json.server.php';
 
 		$time = \time();
 		$key = \hash('sha256', $password);
@@ -43,7 +50,7 @@ class AmpacheClient {
 		$xml = $this->request('handshake', [
 			'auth'      => $passphrase,
 			'timestamp' => $time,
-			'version'   => 350001,
+			'version'   => $version,
 			'user'      => $userName,
 		]);
 
@@ -62,24 +69,11 @@ class AmpacheClient {
 	/**
 	 * requests the given Ampache method and returns an XML object
 	 *
-	 * @param array<string, string> $options
+	 * @param array<string, string> $queryParams
 	 * @throws AmpacheClientException if the XML couldn't be parsed or there is an error in the response
-	 * @throws Exception if the method isn't supported
 	 */
 	public function request(string $method, array $queryParams = []) : \SimpleXMLElement {
-		if (!\in_array($method, ['artists', 'handshake', 'albums', 'songs'])) {
-			throw new Exception('Unsupported method: ' . $method);
-		}
-
-		$queryParams['action'] = $method;
-		if ($this->authToken !== null) {
-			$queryParams['auth'] = $this->authToken;
-		}
-
-		$client = new Client(['verify' => false]);
-		$response = $client->get($this->baseUrl, [
-			'query' => $queryParams
-		]);
+		$response = $this->doRequest($this->baseUrl, $method, $queryParams);
 
 		try {
 			$xml = ClientUtil::getXml($response);
@@ -94,6 +88,63 @@ class AmpacheClient {
 		}
 
 		return $xml;
+	}
+
+	/**
+	 * requests the given Ampache method in the JSON format and returns the parsed JSON
+	 *
+	 * @param array<string, string> $queryParams
+	 * @throws AmpacheClientException if the JSON couldn't be parsed or there is an error in the response
+	 */
+	public function requestJson(string $method, array $queryParams = []) : array {
+		$response = $this->doRequest($this->baseUrlJson, $method, $queryParams);
+
+		$json = \json_decode($response->getBody(), true);
+
+		if (!\is_array($json)) {
+			throw new AmpacheClientException('Could not parse JSON');
+		}
+
+		if (isset($json['error'])) {
+			$error = $json['error'];
+			throw new AmpacheClientException('Ampache error: ' . ($error['errorMessage'] ?? '') . ' (' . ($error['errorCode'] ?? '') . ')');
+		}
+
+		return $json;
+	}
+
+	/**
+	 * Requests an action which is expected to fail, returning the HTTP status along with the parsed body
+	 * instead of throwing. This is needed for the responses which carry meaning in both the status and the
+	 * error body, like the deprecated actions on API6.
+	 *
+	 * @param array<string, string> $queryParams
+	 * @return array{status: int, xml: \SimpleXMLElement}
+	 * @throws AmpacheClientException if the XML couldn't be parsed
+	 */
+	public function requestExpectingError(string $method, array $queryParams = []) : array {
+		$response = $this->doRequest($this->baseUrl, $method, $queryParams, false);
+
+		try {
+			$xml = ClientUtil::getXml($response);
+		} catch (Exception $e) {
+			throw new AmpacheClientException('Could not parse XML', 0, $e);
+		}
+
+		return ['status' => $response->getStatusCode(), 'xml' => $xml];
+	}
+
+	private function doRequest(string $baseUrl, string $method, array $queryParams, bool $throwOnHttpError = true) : ResponseInterface {
+		$queryParams['action'] = $method;
+		if ($this->authToken !== null) {
+			$queryParams['auth'] = $this->authToken;
+		}
+
+		$client = new Client(['verify' => false]);
+		return $client->get($baseUrl, [
+			'query' => $queryParams,
+			'http_errors' => $throwOnHttpError
+		]);
 	}
 
 }

--- a/tests/features/bootstrap/AmpacheContext.php
+++ b/tests/features/bootstrap/AmpacheContext.php
@@ -26,12 +26,32 @@ class AmpacheContext implements Context, SnippetAcceptingContext {
 	/** @var array options to pass to the Ampache API request */
 	private $options = [];
 
+	/** @var array parsed JSON of the latest request made with the JSON format */
+	private $json;
+	/** @var string */
+	private $baseUrl;
+	/** @var string */
+	private $username;
+	/** @var string */
+	private $password;
+
 	/** @var array maps resources to the name of the XML element of the response */
 	private $resourceToXMLElementMapping = [
-		'artists' => 'artist',
-		'albums'  => 'album',
-		'songs'   => 'song',
+		'artists'  => 'artist',
+		'albums'   => 'album',
+		'songs'    => 'song',
+		'catalogs' => 'catalog',
+		'catalog'  => 'catalog',
+		'live_streams'       => 'live_stream',
+		'live_stream'        => 'live_stream',
+		'live_stream_create' => 'live_stream',
 	];
+
+	/** @var array values picked from earlier responses, usable as ":name" in later parameters */
+	private $storedValues = [];
+
+	/** @var int HTTP status of the latest request made with the error-tolerating step */
+	private $errorStatus = 0;
 
 	/**
 	 * Initializes context.
@@ -45,6 +65,9 @@ class AmpacheContext implements Context, SnippetAcceptingContext {
 	 * @param $password
 	 */
 	public function __construct($baseUrl, $username, $password) {
+		$this->baseUrl = $baseUrl;
+		$this->username = $username;
+		$this->password = $password;
 		$this->client = new AmpacheClient($baseUrl, $username, $password);
 	}
 
@@ -58,10 +81,57 @@ class AmpacheContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * The API version is negotiated on the handshake and bound to the session, so switching it means
+	 * logging in again. Without this, all the scenarios run on the oldest supported version.
+	 *
+	 * @Given I am logged in with API version :version
+	 */
+	public function iAmLoggedInWithApiVersion($version) {
+		$this->client = new AmpacheClient($this->baseUrl, $this->username, $this->password, $version);
+		$this->iAmLoggedInWithAnAuthToken();
+	}
+
+	/**
 	 * @When I specify the parameter :option with value :value
 	 */
 	public function iSpecifyTheParameterWithValue($option, $value) {
-		$this->options[$option] = $value;
+		$this->options[$option] = $this->storedValues[\ltrim($value, ':')] ?? $value;
+	}
+
+	/**
+	 * Pick a value from the latest XML response so that it can be used as a parameter of a later request,
+	 * referred to as ":name". This is what makes create-read-update-delete rounds expressible.
+	 *
+	 * @Then I store the :key of the first result as :name
+	 */
+	public function iStoreTheValueOfTheFirstResult($key, $name) {
+		$elements = $this->xml->xpath('/root/' . $this->resourceToXMLElementMapping[$this->resource]);
+		if (empty($elements)) {
+			throw new Exception('No results to store from' . PHP_EOL . $this->xml->asXML());
+		}
+		$found = $elements[0]->xpath($key);
+		if (empty($found)) {
+			throw new Exception("No '$key' in the first result" . PHP_EOL . $this->xml->asXML());
+		}
+		$this->storedValues[$name] = $found[0]->__toString();
+	}
+
+	/**
+	 * @Then the :key of the first result should contain :expected
+	 */
+	public function theValueOfTheFirstResultShouldContain($key, $expected) {
+		$elements = $this->xml->xpath('/root/' . $this->resourceToXMLElementMapping[$this->resource]);
+		if (empty($elements)) {
+			throw new Exception('No results' . PHP_EOL . $this->xml->asXML());
+		}
+		$found = $elements[0]->xpath($key);
+		if (empty($found)) {
+			throw new Exception("No '$key' in the first result" . PHP_EOL . $this->xml->asXML());
+		}
+		$actualValue = $found[0]->__toString();
+		if (\strpos($actualValue, $expected) === false) {
+			throw new Exception("'$actualValue' does not contain '$expected'" . PHP_EOL . $this->xml->asXML());
+		}
 	}
 
 	/**
@@ -70,6 +140,106 @@ class AmpacheContext implements Context, SnippetAcceptingContext {
 	public function iRequestTheResource($resource) {
 		$this->xml = $this->client->request($resource, $this->options);
 		$this->resource = $resource;
+	}
+
+	/**
+	 * Unlike the plain request step, this one tolerates both an error body and a non-200 HTTP status, so
+	 * that the response can be asserted on rather than aborting the scenario.
+	 *
+	 * @When I request the :resource resource expecting an error
+	 */
+	public function iRequestTheResourceExpectingAnError($resource) {
+		$result = $this->client->requestExpectingError($resource, $this->options);
+		$this->errorStatus = $result['status'];
+		$this->xml = $result['xml'];
+		$this->resource = $resource;
+	}
+
+	/**
+	 * @Then the response should not be an error
+	 */
+	public function theResponseShouldNotBeAnError() {
+		$errors = $this->xml->xpath('/root/error');
+		if (!empty($errors)) {
+			throw new Exception('Unexpected error in the response' . PHP_EOL . $this->xml->asXML());
+		}
+	}
+
+	/**
+	 * @Then the response status should be :status
+	 */
+	public function theResponseStatusShouldBe($status) {
+		if ((int)$status !== $this->errorStatus) {
+			throw new Exception("Expected HTTP status $status but got {$this->errorStatus}"
+								. PHP_EOL . $this->xml->asXML());
+		}
+	}
+
+	/**
+	 * The error code is rendered as an attribute of the `error` element while the rest of the error details
+	 * are child elements of it.
+	 *
+	 * @Then the error code should be :code of type :type
+	 */
+	public function theErrorCodeShouldBe($code, $type) {
+		$errors = $this->xml->xpath('/root/error');
+		if (empty($errors)) {
+			throw new Exception('No error in the response' . PHP_EOL . $this->xml->asXML());
+		}
+		$actualCode = (string)($errors[0]->attributes()['errorCode'] ?? '');
+		if ($actualCode !== $code) {
+			throw new Exception("Expected error code $code but got '$actualCode'" . PHP_EOL . $this->xml->asXML());
+		}
+		$actualType = (string)($errors[0]->errorType ?? '');
+		if ($actualType !== $type) {
+			throw new Exception("Expected error type $type but got '$actualType'" . PHP_EOL . $this->xml->asXML());
+		}
+	}
+
+	/**
+	 * @When I request the :resource resource in JSON format
+	 */
+	public function iRequestTheResourceInJson($resource) {
+		$this->json = $this->client->requestJson($resource, $this->options);
+		$this->resource = $resource;
+	}
+
+	/**
+	 * @Then I should get JSON:
+	 */
+	public function iShouldGetJson(TableNode $table) {
+		$key = $this->resourceToXMLElementMapping[$this->resource];
+		if (!\array_key_exists($key, $this->json)) {
+			// API versions below 5 unwrap the outermost array, so the shape depends on the negotiated version
+			throw new Exception("No '$key' in the response: " . \json_encode($this->json));
+		}
+		$elements = $this->json[$key];
+
+		$expectedIterator = $table->getIterator();
+		foreach ($elements as $element) {
+			$expectedElement = $expectedIterator->current();
+			$expectedIterator->next();
+
+			if ($expectedElement === null) {
+				throw new Exception('More results than expected');
+			}
+
+			foreach ($expectedElement as $key => $expectedValue) {
+				$actualValue = $element[$key];
+				// the table always carries strings, so compare loosely to accept ints and bools as well
+				if ($actualValue != $expectedValue) {
+					throw new Exception(\ucfirst($key) . " does not match - expected: '$expectedValue'"
+										. " got: '" . \var_export($actualValue, true) . "'" . PHP_EOL . \json_encode($this->json));
+				}
+			}
+		}
+
+		$expectedCount = \count($table->getHash());
+		$actualCount = \count($elements);
+		if ($expectedCount !== $actualCount) {
+			throw new Exception('Not all elements are in the result set - ' . $actualCount
+								. ' does not match the expected ' . $expectedCount . PHP_EOL . \json_encode($this->json));
+		}
 	}
 
 	/**


### PR DESCRIPTION
Tag actions became Genre actions in API5+ so add deprecation warning to push people to the correct function names instead of allowing them