### PR TITLE
Stream files on encrypted and other non-seekable storages more robustly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 - Extensive internal refactoring on the web UI
 
 ### Fixed
+- Streaming of files on encrypted or other non-seekable storages: seek failures are no longer silently ignored, files with no known size are streamed without a declared length, and a failure to open the file is reported as HTTP 403 instead of 500
+  [#19](https://github.com/nc-music/music/issues/19)
 - HTTP redirection not working (e.g. on radio streams) when the `Location` header contains a relative URL
 - Deprecation warnings printed on PHP 8.3+ while executing the Music background tasks
 - Web UI trying to load an invalid image URL upon page load

--- a/lib/Controller/AmpacheController.php
+++ b/lib/Controller/AmpacheController.php
@@ -1364,7 +1364,7 @@ class AmpacheController extends ApiController {
 					if ($stats) {
 						$this->record_play($id, null);
 					}
-					return new FileStreamResponse($file);
+					return new FileStreamResponse($file, $this->logger);
 				} else {
 					return new ErrorResponse(Http::STATUS_NOT_FOUND, "File for song $id does not exist");
 				}

--- a/lib/Controller/MusicApiController.php
+++ b/lib/Controller/MusicApiController.php
@@ -181,7 +181,7 @@ class MusicApiController extends Controller {
 		$nodes = $this->scanner->resolveUserFolder($this->user())->getById($fileId);
 		$node = $nodes[0] ?? null;
 		if ($node instanceof \OCP\Files\File) {
-			return new FileStreamResponse($node);
+			return new FileStreamResponse($node, $this->logger);
 		}
 
 		return new ErrorResponse(Http::STATUS_NOT_FOUND, 'file not found');

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -83,7 +83,7 @@ class ShareController extends Controller {
 			$sharedFolder = $this->getSharedFolder($token);
 			$file = $sharedFolder->getById($fileId)[0] ?? null;
 			if ($file instanceof File) {
-				return new FileStreamResponse($file);
+				return new FileStreamResponse($file, $this->logger);
 			} else {
 				return new ErrorResponse(Http::STATUS_NOT_FOUND, 'no such file under the share');
 			}

--- a/lib/Controller/SubsonicController.php
+++ b/lib/Controller/SubsonicController.php
@@ -470,7 +470,7 @@ class SubsonicController extends ApiController {
 			$file = $this->getFilesystemNode($track->getFileId());
 
 			if ($file instanceof File) {
-				return new FileStreamResponse($file);
+				return new FileStreamResponse($file, $this->logger);
 			} else {
 				return $this->subsonicErrorResponse(70, 'file not found');
 			}

--- a/lib/Http/FileStreamResponse.php
+++ b/lib/Http/FileStreamResponse.php
@@ -7,11 +7,12 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2021 - 2025
+ * @copyright Pauli Järvinen 2021 - 2026
  */
 
 namespace OCA\Music\Http;
 
+use OCA\Music\AppFramework\Core\Logger;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\ICallbackResponse;
 use OCP\AppFramework\Http\IOutput;
@@ -22,21 +23,34 @@ use OCP\Files\File;
  * A renderer for files
  */
 class FileStreamResponse extends Response implements ICallbackResponse {
+	private const COPY_CHUNK_SIZE = 65536;
+
 	private File $file;
+	private Logger $logger;
 	private int $start;
 	private int $end;
+	/** True when the size of the file is not known in advance and can't be declared in the headers */
+	private bool $unknownSize;
 
-	public function __construct(File $file) {
+	public function __construct(File $file, Logger $logger) {
 
 		$this->file = $file;
+		$this->logger = $logger;
 		$mime = $file->getMimetype();
 		$size = $file->getSize();
 		$this->start = 0;
 		$this->end = $size - 1;
+		$this->unknownSize = ($size <= 0);
 
 		$this->addHeader('Content-type', "$mime; charset=utf-8");
 
-		if (isset($_SERVER['HTTP_RANGE'])) {
+		if ($this->unknownSize) {
+			// The size may be missing from the file cache e.g. on an encrypted storage which has not recorded
+			// the unencrypted size. Streaming without declaring the length is better than refusing the request,
+			// which is what the range arithmetic below would end up doing with a non-positive size.
+			$this->logger->warning("Unknown size for the file {$file->getId()}, streaming without Content-Length");
+			$this->setStatus(Http::STATUS_OK);
+		} elseif (isset($_SERVER['HTTP_RANGE'])) {
 			// Note that we do not support Range Header of the type
 			// bytes=x-y,z-w
 			if (!\preg_match('/^bytes=\d*-\d*$/', $_SERVER['HTTP_RANGE'])) {
@@ -71,7 +85,16 @@ class FileStreamResponse extends Response implements ICallbackResponse {
 		$status = $this->getStatus();
 
 		if ($status === Http::STATUS_OK || $status === Http::STATUS_PARTIAL_CONTENT) {
-			$fp = $this->file->fopen('r');
+			try {
+				$fp = $this->file->fopen('r');
+			} catch (\Throwable $e) {
+				// With the per-user-key server-side encryption, the file can be decrypted only within a cloud
+				// login session which has unlocked the private key of the user. The Ampache and Subsonic clients
+				// authenticate with an API key and have no such session, so the decryption fails for them.
+				$this->logger->error("Failed to open the file {$this->file->getId()} for reading: {$e->getMessage()}");
+				$output->setHttpResponseCode(Http::STATUS_FORBIDDEN);
+				return;
+			}
 
 			if (!\is_resource($fp)) {
 				$output->setHttpResponseCode(Http::STATUS_NOT_FOUND);
@@ -89,15 +112,62 @@ class FileStreamResponse extends Response implements ICallbackResponse {
 	 */
 	private function streamDataToOutput($fp) : bool {
 		// Request Range Not Satisfiable
-		if ($this->start > $this->end) {
+		if (!$this->unknownSize && $this->start > $this->end) {
 			return false;
-		} else {
-			$outputStream = \fopen('php://output', 'w');
-			$length = $this->end - $this->start + 1;
-			$bytesCopied = \stream_copy_to_stream($fp, $outputStream, $length, $this->start);
-			\fclose($outputStream);
-			return ($bytesCopied > 0);
 		}
+
+		$outputStream = \fopen('php://output', 'w');
+		if (!\is_resource($outputStream)) {
+			return false;
+		}
+
+		if ($this->unknownSize) {
+			$bytesCopied = \stream_copy_to_stream($fp, $outputStream);
+		} else {
+			$length = $this->end - $this->start + 1;
+
+			// Don't let stream_copy_to_stream() do the seeking. On the wrapped streams of the encrypted and the
+			// SMB storages, the seek may fail, and the copying would then silently start from the wrong offset.
+			if (!self::seekTo($fp, $this->start)) {
+				\fclose($outputStream);
+				$this->logger->error("Failed to seek to the offset {$this->start} of the file {$this->file->getId()}");
+				return false;
+			}
+
+			$bytesCopied = \stream_copy_to_stream($fp, $outputStream, $length);
+
+			if ($bytesCopied !== $length) {
+				// The declared size comes from the file cache and may not match the actual decrypted content,
+				// in which case the client gets a truncated or a stalled stream.
+				$this->logger->warning("Streamed $bytesCopied bytes of the file {$this->file->getId()} while "
+									. "$length bytes were declared in the response headers");
+			}
+		}
+
+		\fclose($outputStream);
+		return ($bytesCopied > 0);
+	}
+
+	/**
+	 * Move the file handle to the given offset. Streams which don't support seeking are advanced by reading
+	 * and discarding the leading bytes.
+	 * @param resource $fp File handle
+	 */
+	private static function seekTo($fp, int $offset) : bool {
+		if ($offset === 0 || \fseek($fp, $offset) === 0) {
+			return true;
+		}
+
+		$remaining = $offset;
+		while ($remaining > 0 && !\feof($fp)) {
+			$chunk = \fread($fp, \min($remaining, self::COPY_CHUNK_SIZE));
+			if ($chunk === false || $chunk === '') {
+				return false;
+			}
+			$remaining -= \strlen($chunk);
+		}
+
+		return ($remaining <= 0);
 	}
 
 }


### PR DESCRIPTION
I don't have encrypted Nextcloud storage so this one is a bit of a black box for me. If someone is able to test this code out it should be helpful as reporting length of 0 to a client is worse than not reporting a length at all.

Refs #19