### PR TITLE
Fix metadata being lost for files with an ID3v2.3 involved parseId3ContributorList

### DIFF
--- a/lib/Service/ExtractorGetID3.php
+++ b/lib/Service/ExtractorGetID3.php
@@ -206,11 +206,35 @@ class ExtractorGetID3 {
 	}
 
 	/**
-	 * @param string[] $contributors E.g. ['role1', 'name1a', 'role1', 'name1b', 'role2', 'name2', ...]
+	 * @param array $contributors Flat list ['role1', 'name1a', 'role1', 'name1b', ...] from the ID3v2.4 frames
+	 *                            TIPL and TMCL, or nested [[['position' => 'role1', 'person' => 'name1a'], ...]]
+	 *                            from the ID3v2.3 frame IPLS, which GetID3 pairs up itself.
 	 * @return array<string, string[]> E.g. ['role1' => ['name1a', 'name1b'], 'role2' => ['name2']]
 	 */
 	private static function parseId3ContributorList(array $contributors) : array {
 		$result = [];
+
+		// Any IPLS frame arrives nested and already paired up; the flat parsing below would use an array as an array key, fatal on PHP 8.
+		if (\is_array($contributors[0] ?? null)) {
+			foreach ($contributors as $frame) {
+				foreach ($frame as $pair) {
+					if (\is_array($pair)) {
+						// a frame with an odd number of null-delimited parts yields role-less entries like ['name']
+						$role = $pair['position'] ?? '';
+						$name = $pair['person'] ?? $pair[0] ?? null;
+					} else {
+						// a frame with no null delimiters at all is split to bare names on the punctuation
+						$role = '';
+						$name = $pair;
+					}
+					if (\is_string($name) && $name !== '') {
+						$result[$role][] = $name;
+					}
+				}
+			}
+			return $result;
+		}
+
 		while (\count($contributors)) {
 			$role = \array_shift($contributors);
 			$name = \array_shift($contributors);


### PR DESCRIPTION
Some of my MP3s were showing up as Unknown Artist even though the tags were fine. The Nextcloud log had a TypeError from `parseId3ContributorList`.

As far as I can tell, the cause is that getID3 handles the ID3v2.3 `IPLS` frame differently from the ID3v2.4 `TIPL` and `TMCL` frames. For v2.4 it gives a flat list:

    ['role1', 'name1', 'role2', 'name2', ...]

For v2.3 it pairs them up itself and nests the result:

    [[['position' => 'role1', 'person' => 'name1'], ...]]

`parseId3ContributorList` assumed the flat shape, so it passed an array to `array_shift` and then used it as an array key. That is a TypeError on PHP 8. `ExtractorGetID3::extract` catches it and returns an empty array, so the file loses every tag and the scanner falls back to the file name.

This adds a separate branch for the nested shape. getID3 has a few different outputs for `IPLS` depending on how well-formed the frame is (see `module.tag.id3v2.php` around line 840), so names it could not pair with a role are stored under an empty role instead of being dropped.

I have not added a test, since there is no existing test for this class and the method is private. Happy to add one if you would like.

I am not particularly familiar with the ID3 spec, so please check whether the fallback handling is what you would want here.

The changes were working properly on my local nextCloud instance.

Hopefully this will help. Thanks!
